### PR TITLE
fix: stop service and notification on intentional disconnect

### DIFF
--- a/app/src/main/kotlin/com/kelsos/mbrc/service/ServiceLifecycleManager.kt
+++ b/app/src/main/kotlin/com/kelsos/mbrc/service/ServiceLifecycleManager.kt
@@ -91,12 +91,14 @@ class ServiceLifecycleManagerImpl(
   override fun onIntentionalDisconnect() {
     Timber.d("Intentional disconnect requested")
     intentionalDisconnect.set(true)
-    // Also cancel any ongoing reconnection
+    // Cancel any ongoing reconnection
     isReconnecting.set(false)
     reconnectionCycle.set(0)
     reconnectionJob?.cancel()
     reconnectionJob = null
     stopPending.set(false)
+    // Stop the service and remove the notification
+    stopService()
   }
 
   override fun onConnectionRestored() {


### PR DESCRIPTION
## Summary
- When the user manually disconnects via the drawer toggle, the service and notification were left running because `onIntentionalDisconnect` only prevented reconnection without stopping the service. Now it also calls `stopService` to properly clean up.

## Test plan
- [x] Unit tests pass
- [x] Installed on device and verified service stops on manual disconnect