### PR TITLE
fix: resolve stale notification and improve connection indicator

### DIFF
--- a/app/src/main/kotlin/com/kelsos/mbrc/service/mediasession/AppNotificationManager.kt
+++ b/app/src/main/kotlin/com/kelsos/mbrc/service/mediasession/AppNotificationManager.kt
@@ -104,10 +104,14 @@ class AppNotificationManagerImpl(
       val mediaSession = mediaSessionManager.mediaSession ?: return
       notification = notificationBuilder.createBuilder(this.notificationData, mediaSession).build()
       notificationManager.notify(AppNotificationManager.MEDIA_SESSION_NOTIFICATION_ID, notification)
+    } else {
+      // Replace the notification with a placeholder to indicate disconnection.
+      // The ServiceLifecycleManager will eventually stop the service and remove it,
+      // but this avoids showing stale track data during the reconnection window.
+      notificationData = NotificationData()
+      notification = notificationBuilder.createPlaceholderBuilder().build()
+      notificationManager.notify(AppNotificationManager.MEDIA_SESSION_NOTIFICATION_ID, notification)
     }
-    // When disconnected, don't cancel the notification here.
-    // The ServiceLifecycleManager will stop the service, and stopForeground(REMOVE)
-    // will handle notification removal safely.
   }
 
   override fun updateState(state: PlayerState, position: PlayingPosition) {

--- a/app/src/main/kotlin/com/kelsos/mbrc/service/mediasession/MediaSessionManager.kt
+++ b/app/src/main/kotlin/com/kelsos/mbrc/service/mediasession/MediaSessionManager.kt
@@ -30,8 +30,9 @@ class MediaSessionManager(
   private val dispatchers: AppCoroutineDispatchers
 ) {
   private var _mediaSession: MediaSession? = null
-  private val sessionJob: Job = Job()
-  val scope: CoroutineScope = CoroutineScope(sessionJob)
+  private var sessionJob: Job = Job()
+  var scope: CoroutineScope = CoroutineScope(sessionJob)
+    private set
 
   /**
    * Initializes the media session if it doesn't already exist.
@@ -42,6 +43,12 @@ class MediaSessionManager(
   fun initialize(): MediaSession {
     if (_mediaSession != null) {
       return requireNotNull(_mediaSession)
+    }
+
+    // Recreate scope if it was cancelled by a previous destroy() call
+    if (sessionJob.isCancelled) {
+      sessionJob = Job()
+      scope = CoroutineScope(sessionJob)
     }
 
     val player =

--- a/app/src/main/kotlin/com/kelsos/mbrc/state/AppStateManager.kt
+++ b/app/src/main/kotlin/com/kelsos/mbrc/state/AppStateManager.kt
@@ -75,35 +75,32 @@ class AppStateManager(
     }
 
     launch {
-      // Track if we were ever connected to avoid triggering reconnection logic on initial Offline state
-      var wasConnected = false
+      // Track if a connection was ever attempted to avoid triggering
+      // reconnection logic on the initial Offline state (which is the default)
+      var wasConnectionAttempted = false
 
       connectionState.connection.collect { connection ->
         notifications.connectionStateChanged(connection == ConnectionStatus.Connected)
         when (connection) {
           ConnectionStatus.Offline -> {
             stopPositionUpdater()
-            // Only track connection loss if we were previously connected
-            // This prevents stopping the service immediately on startup
-            if (wasConnected) {
+            if (wasConnectionAttempted) {
               serviceLifecycleManager.onConnectionLost()
             }
           }
 
           ConnectionStatus.Connected -> {
-            wasConnected = true
+            wasConnectionAttempted = true
             serviceLifecycleManager.onConnectionRestored()
           }
 
           ConnectionStatus.Authenticating -> {
-            // Authenticating means we're in the process of connecting,
-            // so reset reconnection tracking
+            wasConnectionAttempted = true
             serviceLifecycleManager.onConnectionRestored()
           }
 
           is ConnectionStatus.Connecting -> {
-            // Actively connecting - no action needed, ServiceLifecycleManager
-            // is already aware of reconnection attempts
+            wasConnectionAttempted = true
           }
         }
       }

--- a/app/src/main/kotlin/com/kelsos/mbrc/ui/AppDrawer.kt
+++ b/app/src/main/kotlin/com/kelsos/mbrc/ui/AppDrawer.kt
@@ -60,6 +60,7 @@ import com.kelsos.mbrc.BuildConfig
 import com.kelsos.mbrc.R
 import com.kelsos.mbrc.core.common.state.ConnectionStatus
 import com.kelsos.mbrc.core.ui.theme.connection_status_connected
+import com.kelsos.mbrc.core.ui.theme.connection_status_connecting
 import com.kelsos.mbrc.core.ui.theme.connection_status_offline
 import com.kelsos.mbrc.core.ui.theme.drawer_header_gradient_top_dark
 import com.kelsos.mbrc.core.ui.theme.drawer_header_gradient_top_light
@@ -291,8 +292,8 @@ private fun ConnectionStatusIconButton(
 ) {
   val (statusColor, statusIcon) = when (connectionState) {
     ConnectionStatus.Connected -> connection_status_connected to Icons.Default.Wifi
-    is ConnectionStatus.Connecting -> MaterialTheme.colorScheme.secondary to Icons.Default.Wifi
-    ConnectionStatus.Authenticating -> MaterialTheme.colorScheme.secondary to Icons.Default.Wifi
+    is ConnectionStatus.Connecting -> connection_status_connecting to Icons.Default.Wifi
+    ConnectionStatus.Authenticating -> connection_status_connecting to Icons.Default.Wifi
     ConnectionStatus.Offline -> connection_status_offline to Icons.Default.WifiOff
   }
 

--- a/core/ui/src/main/kotlin/com/kelsos/mbrc/core/ui/theme/Color.kt
+++ b/core/ui/src/main/kotlin/com/kelsos/mbrc/core/ui/theme/Color.kt
@@ -83,6 +83,7 @@ val drawer_header_gradient_bottom_dark = Color(0xFFBF360C) // Deep Orange 900 da
 
 // Connection Status Colors
 val connection_status_connected = Color(0xFF4CAF50) // Green
+val connection_status_connecting = Color(0xFFC62828) // Red 800
 val connection_status_offline = Color(0xFFC62828) // Red 800
 val connection_status_card_bg_light = Color(0xFFE0E0E0) // Light gray for better visibility
 val connection_status_card_bg_dark = Color.White.copy(alpha = 0.15f)


### PR DESCRIPTION
## Summary
- Fix notification becoming permanently stale after a service restart cycle — the `MediaSessionManager` coroutine scope was never recreated after `destroy()`, causing all notification updates to silently fail
- Show placeholder notification on disconnect instead of leaving stale track data during the reconnection window
- Use dark red for the connecting progress indicator in the drawer for better contrast against the header gradient
- Trigger reconnection/cleanup logic when a connection attempt fails, not only when a previously established connection is lost

## Test plan
- [ ] Connect to MusicBee, change tracks — notification should update
- [ ] Disconnect and reconnect — notification should update after reconnect
- [ ] Kill MusicBee while connected — notification should show placeholder, then be removed after reconnection fails
- [ ] Start app with MusicBee offline — service should clean up after failed connection attempts
- [ ] Verify connecting indicator in drawer uses dark red with good contrast