### PR TITLE
chore: bump version to 1.6.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog
 -----------
 
 ## [Unreleased]
+
+## [1.6.0-rc.1] - 2026-04-15
 ### Added
 - [#231] Adds play all and shuffle all library options to the library menu.
 - [#230] Displays composer information in the lyrics screen header.
@@ -245,7 +247,8 @@ Changelog
 - Removes the dialogs that used to appear on each new setup.
 
 
-[Unreleased]: https://github.com/musicbeeremote/mbrc/compare/v1.5.1...HEAD
+[Unreleased]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0-rc.1...HEAD
+[1.6.0-rc.1]: https://github.com/musicbeeremote/mbrc/compare/v1.5.1...v1.6.0-rc.1
 [1.5.1]: https://github.com/musicbeeremote/mbrc/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/musicbeeremote/mbrc/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/musicbeeremote/mbrc/compare/v1.3.0...v1.4.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -92,8 +92,8 @@ val buildTimeProvider = providers.provider {
   df.format(Date())
 }
 
-val appVersionName = "1.6.0-alpha.1"
-val appVersionCode = 125
+val appVersionName = "1.6.0-rc.1"
+val appVersionCode = 126
 val minSDKVersion = 23
 val compileSDKVersion = 36
 

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <changelog>
   <version
-    version="1.6.0"
-    release="Jan 31, 2026">
+    version="1.6.0-rc.1"
+    release="Apr 15, 2026">
     <feature>Adds play all and shuffle all library options to the library menu.</feature>
     <feature>Displays composer information in the lyrics screen header.</feature>
     <feature>Adds track details panel showing extended metadata (composer, genre, bitrate, file info, play statistics).</feature>


### PR DESCRIPTION
## Summary
- Bumps version name to `1.6.0-rc.1` and version code to `126`
- Updates CHANGELOG.md with the 1.6.0-rc.1 release date
- Updates the in-app What's New changelog XML

## Test plan
- [ ] CI passes (build, tests, lint, detekt)
- [ ] Merge and tag `v1.6.0-rc.1` to trigger the release workflow