### PR TITLE
chore: bump version to 1.6.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 ## [Unreleased]
 
+## [1.6.0-rc.2] - 2026-04-18
+### Fixed
+- Fixes Google Services configuration for the Play release build.
+
 ## [1.6.0-rc.1] - 2026-04-15
 ### Added
 - [#231] Adds play all and shuffle all library options to the library menu.
@@ -247,7 +251,8 @@ Changelog
 - Removes the dialogs that used to appear on each new setup.
 
 
-[Unreleased]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0-rc.1...HEAD
+[Unreleased]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0-rc.2...HEAD
+[1.6.0-rc.2]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0-rc.1...v1.6.0-rc.2
 [1.6.0-rc.1]: https://github.com/musicbeeremote/mbrc/compare/v1.5.1...v1.6.0-rc.1
 [1.5.1]: https://github.com/musicbeeremote/mbrc/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/musicbeeremote/mbrc/compare/v1.4.0...v1.5.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -92,8 +92,8 @@ val buildTimeProvider = providers.provider {
   df.format(Date())
 }
 
-val appVersionName = "1.6.0-rc.1"
-val appVersionCode = 126
+val appVersionName = "1.6.0-rc.2"
+val appVersionCode = 127
 val minSDKVersion = 23
 val compileSDKVersion = 36
 

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <changelog>
   <version
+    version="1.6.0-rc.2"
+    release="Apr 18, 2026">
+    <bug>Fixes Google Services configuration for the Play release build.</bug>
+  </version>
+  <version
     version="1.6.0-rc.1"
     release="Apr 15, 2026">
     <feature>Adds play all and shuffle all library options to the library menu.</feature>


### PR DESCRIPTION
## Summary
- Bumps version to 1.6.0-rc.2 (versionCode 127)
- Fixes Google Services configuration for the Play release build; no code changes

## Test plan
- [ ] CI passes
- [ ] Play release build succeeds with correct google-services.json