### PR TITLE
fix: don't crash when no default connection is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog
 -----------
 
 ## [Unreleased]
+### Fixed
+- Fixes a crash when opening the output selection (or any other API call) before a default connection is configured.
 
 ## [1.6.0-rc.2] - 2026-04-18
 ### Fixed

--- a/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/NoDefaultConnectionException.kt
+++ b/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/NoDefaultConnectionException.kt
@@ -1,0 +1,5 @@
+package com.kelsos.mbrc.core.networking
+
+import java.io.IOException
+
+class NoDefaultConnectionException : IOException("No default connection is configured")

--- a/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/RequestManager.kt
+++ b/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/RequestManager.kt
@@ -90,7 +90,8 @@ class RequestManagerImpl(
     }
 
   private fun connect(firstMessage: SocketMessage?): Socket {
-    val connectionSettings = checkNotNull(connectionProvider.getDefault())
+    val connectionSettings = connectionProvider.getDefault()
+      ?: throw NoDefaultConnectionException()
 
     try {
       Timber.v("Preparing connection to $connectionSettings")

--- a/core/networking/src/test/kotlin/com/kelsos/mbrc/core/networking/RequestManagerImplTest.kt
+++ b/core/networking/src/test/kotlin/com/kelsos/mbrc/core/networking/RequestManagerImplTest.kt
@@ -1,0 +1,56 @@
+package com.kelsos.mbrc.core.networking
+
+import com.google.common.truth.Truth.assertThat
+import com.kelsos.mbrc.core.common.test.testDispatcher
+import com.kelsos.mbrc.core.common.test.testDispatcherModule
+import com.kelsos.mbrc.core.common.utilities.coroutines.AppCoroutineDispatchers
+import com.kelsos.mbrc.core.networking.data.DeserializationAdapter
+import com.kelsos.mbrc.core.networking.data.SerializationAdapter
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.test.KoinTest
+import org.koin.test.inject
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class RequestManagerImplTest : KoinTest {
+
+  private val dispatchers: AppCoroutineDispatchers by inject()
+
+  @Before
+  fun setUp() {
+    startKoin { modules(testDispatcherModule) }
+  }
+
+  @After
+  fun tearDown() {
+    stopKoin()
+  }
+
+  @Test
+  fun `openConnection throws NoDefaultConnectionException when no default is configured`() =
+    runTest(testDispatcher) {
+      val connectionProvider = mockk<DefaultConnectionProvider>()
+      every { connectionProvider.getDefault() } returns null
+
+      val manager = RequestManagerImpl(
+        serializationAdapter = mockk<SerializationAdapter>(relaxed = true),
+        deserializationAdapter = mockk<DeserializationAdapter>(relaxed = true),
+        clientIdProvider = mockk<ClientIdProvider>(relaxed = true),
+        connectionProvider = connectionProvider,
+        dispatchers = dispatchers
+      )
+
+      val thrown = runCatching { manager.openConnection() }.exceptionOrNull()
+      assertThat(thrown).isInstanceOf(NoDefaultConnectionException::class.java)
+    }
+}

--- a/feature/misc/src/main/kotlin/com/kelsos/mbrc/feature/misc/output/OutputSelectionViewModel.kt
+++ b/feature/misc/src/main/kotlin/com/kelsos/mbrc/feature/misc/output/OutputSelectionViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.kelsos.mbrc.core.common.utilities.AppError
 import com.kelsos.mbrc.core.common.utilities.Outcome
 import com.kelsos.mbrc.core.common.utilities.coroutines.AppCoroutineDispatchers
+import com.kelsos.mbrc.core.networking.NoDefaultConnectionException
 import com.kelsos.mbrc.core.networking.api.OutputApi
 import com.kelsos.mbrc.core.networking.dto.OutputResponse
 import java.net.SocketException
@@ -27,6 +28,7 @@ class OutputSelectionViewModel(
 
   private fun mapError(throwable: Throwable?): Outcome<Unit> =
     when (throwable?.cause ?: throwable) {
+      is NoDefaultConnectionException -> Outcome.Failure(AppError.NotConnected)
       is SocketException -> Outcome.Failure(AppError.ConnectionRefused)
       is SocketTimeoutException -> Outcome.Failure(AppError.NetworkTimeout)
       else -> Outcome.Failure(AppError.Unknown(throwable))

--- a/feature/misc/src/test/kotlin/com/kelsos/mbrc/feature/misc/output/OutputSelectionViewModelTest.kt
+++ b/feature/misc/src/test/kotlin/com/kelsos/mbrc/feature/misc/output/OutputSelectionViewModelTest.kt
@@ -6,6 +6,7 @@ import com.kelsos.mbrc.core.common.test.testDispatcher
 import com.kelsos.mbrc.core.common.test.testDispatcherModule
 import com.kelsos.mbrc.core.common.utilities.AppError
 import com.kelsos.mbrc.core.common.utilities.Outcome
+import com.kelsos.mbrc.core.networking.NoDefaultConnectionException
 import com.kelsos.mbrc.core.networking.api.OutputApi
 import com.kelsos.mbrc.core.networking.dto.OutputResponse
 import io.mockk.coEvery
@@ -121,6 +122,21 @@ class OutputSelectionViewModelTest : KoinTest {
         val event = awaitItem()
         assertThat(event).isInstanceOf(Outcome.Failure::class.java)
         assertThat((event as Outcome.Failure).error).isEqualTo(AppError.NetworkTimeout)
+      }
+    }
+
+  @Test
+  fun `reload should emit NotConnected error when no default connection is configured`() =
+    runTest(testDispatcher) {
+      coEvery { outputApi.getOutputs() } throws NoDefaultConnectionException()
+
+      viewModel.events.test {
+        viewModel.reload()
+        advanceUntilIdle()
+
+        val event = awaitItem()
+        assertThat(event).isInstanceOf(Outcome.Failure::class.java)
+        assertThat((event as Outcome.Failure).error).isEqualTo(AppError.NotConnected)
       }
     }
 


### PR DESCRIPTION
## Summary
- `RequestManagerImpl.connect` used `checkNotNull(connectionProvider.getDefault())`, crashing the app with `IllegalStateException` whenever an API call fired before a default connection was set up.
- Surfaced via Play Console pre-launch testing on emulator; the Output Selection bottom sheet is reachable from the Player without a connection, and calls `outputApi.getOutputs()` immediately on open.
- Also a plausible path for users whose `DefaultConnectionMigration` (SharedPreferences → Room) didn't yield a default row on upgrade.

## Fix
- New `NoDefaultConnectionException : IOException` in `core/networking`.
- Replace `checkNotNull` with a typed throw — existing `IOException` handlers now produce a user-facing error instead of a crash.
- Map it to `AppError.NotConnected` in `OutputSelectionViewModel`.

## Tests
- `RequestManagerImplTest` — verifies `openConnection` throws `NoDefaultConnectionException` when `getDefault()` returns null.
- `OutputSelectionViewModelTest` — new case asserting the `NotConnected` mapping.

## Test plan
- [x] `./gradlew :core:networking:testDebugUnitTest --tests "*RequestManagerImplTest"`
- [x] `./gradlew :feature:misc:testDebugUnitTest --tests "*OutputSelectionViewModelTest"`
- [x] `./gradlew formatKotlin detekt`
- [ ] CI passes