### PR TITLE
fix: don't crash on cover protocol messages with null cover field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 ## [Unreleased]
 ### Fixed
 - Fixes a crash when opening the output selection (or any other API call) before a default connection is configured.
+- Fixes a crash when the plugin sends a cover protocol message with a null `cover` field.
 
 ## [1.6.0-rc.2] - 2026-04-18
 ### Fixed

--- a/app/src/main/kotlin/com/kelsos/mbrc/adapters/ProtocolActionAdapters.kt
+++ b/app/src/main/kotlin/com/kelsos/mbrc/adapters/ProtocolActionAdapters.kt
@@ -138,7 +138,8 @@ class CoverHandlerImpl(
   override suspend fun fetchAndStoreCover(): String = withContext(dispatchers.network) {
     val result = runCatching {
       val response = playbackApi.getCover()
-      val bitmap = getBitmap(response.cover)
+      val cover = checkNotNull(response.cover) { "Cover payload had no cover data" }
+      val bitmap = getBitmap(cover)
       val file = storeCover(bitmap)
       file.toUri().toString()
     }

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <changelog>
   <version
+    version="Unreleased"
+    release="">
+    <bug>Fixes a crash when opening the output selection (or any other API call) before a default connection is configured.</bug>
+    <bug>Fixes a crash when the plugin sends a cover protocol message with a null cover field.</bug>
+  </version>
+  <version
     version="1.6.0-rc.2"
     release="Apr 18, 2026">
     <bug>Fixes Google Services configuration for the Play release build.</bug>

--- a/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/protocol/payloads/CoverPayload.kt
+++ b/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/protocol/payloads/CoverPayload.kt
@@ -8,7 +8,7 @@ data class CoverPayload(
   @Json(name = "status")
   val status: Int = NOT_FOUND,
   @Json(name = "cover")
-  val cover: String = ""
+  val cover: String? = null
 ) {
   companion object {
     const val READY = 1

--- a/core/networking/src/test/kotlin/com/kelsos/mbrc/core/networking/protocol/payloads/CoverPayloadTest.kt
+++ b/core/networking/src/test/kotlin/com/kelsos/mbrc/core/networking/protocol/payloads/CoverPayloadTest.kt
@@ -1,0 +1,37 @@
+package com.kelsos.mbrc.core.networking.protocol.payloads
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.moshi.Moshi
+import org.junit.Test
+
+class CoverPayloadTest {
+
+  private val adapter = Moshi.Builder().build().adapter(CoverPayload::class.java)
+
+  @Test
+  fun `parses payload with populated cover`() {
+    val payload = adapter.fromJson("""{"status":200,"cover":"base64data"}""")
+
+    assertThat(payload).isNotNull()
+    assertThat(payload!!.status).isEqualTo(CoverPayload.SUCCESS)
+    assertThat(payload.cover).isEqualTo("base64data")
+  }
+
+  @Test
+  fun `parses payload when cover field is explicitly null`() {
+    val payload = adapter.fromJson("""{"status":404,"cover":null}""")
+
+    assertThat(payload).isNotNull()
+    assertThat(payload!!.status).isEqualTo(CoverPayload.NOT_FOUND)
+    assertThat(payload.cover).isNull()
+  }
+
+  @Test
+  fun `parses payload when cover field is missing`() {
+    val payload = adapter.fromJson("""{"status":1}""")
+
+    assertThat(payload).isNotNull()
+    assertThat(payload!!.status).isEqualTo(CoverPayload.READY)
+    assertThat(payload.cover).isNull()
+  }
+}


### PR DESCRIPTION
## Summary
- `CoverPayloadJsonAdapter` threw `JsonDataException: Non-null value 'cover' was null at $.cover` when the plugin sent `{"cover": null, ...}` for `NowPlayingCover` — Moshi defaults only apply when the key is absent, not when it's present-but-null. Seen as Crashlytics issue `f90c609d5a59219a311e306448f7d9be` on 1.6.0-rc.2.
- `UpdateCover.execute` only reads `payload.status`, so `cover` is made nullable.
- Added a `CoverPayloadTest` covering populated / explicit-null / missing-key cases as a regression test.
- Changelog entries added to both `CHANGELOG.md` and `app/src/main/res/raw/changelog.xml` (backfilled the prior unreleased connection-fix entry that wasn't in the xml).

## Test plan
- [x] `./gradlew :core:networking:testDebugUnitTest --tests "*CoverPayloadTest*"`
- [ ] Verify no cover-related crashes on next release candidate