### PR TITLE
fix: normalize last_version_run to Long to avoid ClassCastException on upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 ### Fixed
 - Fixes a crash when opening the output selection (or any other API call) before a default connection is configured.
 - Fixes a crash when the plugin sends a cover protocol message with a null `cover` field.
+- Fixes a startup crash for users upgrading from legacy versions caused by a type mismatch on the stored last-run version code.
 
 ## [1.6.0-rc.2] - 2026-04-18
 ### Fixed

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -5,6 +5,7 @@
     release="">
     <bug>Fixes a crash when opening the output selection (or any other API call) before a default connection is configured.</bug>
     <bug>Fixes a crash when the plugin sends a cover protocol message with a null cover field.</bug>
+    <bug>Fixes a startup crash for users upgrading from legacy versions caused by a type mismatch on the stored last-run version code.</bug>
   </version>
   <version
     version="1.6.0-rc.2"

--- a/feature/settings/src/main/kotlin/com/kelsos/mbrc/feature/settings/data/SettingsDataStore.kt
+++ b/feature/settings/src/main/kotlin/com/kelsos/mbrc/feature/settings/data/SettingsDataStore.kt
@@ -1,30 +1,58 @@
 package com.kelsos.mbrc.feature.settings.data
 
 import android.content.Context
+import androidx.datastore.core.DataMigration
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.SharedPreferencesMigration
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
-import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 
 object SettingsDataStore {
   private const val SETTINGS_NAME = "settings"
+  private const val LAST_VERSION_RUN_KEY_NAME = "last_version_run"
 
   val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
     name = SETTINGS_NAME,
     produceMigrations = { context ->
-      // Migrate from default SharedPreferences
       listOf(
         SharedPreferencesMigration(
           context = context,
           sharedPreferencesName = context.packageName + "_preferences"
-        )
+        ),
+        lastVersionRunTypeMigration()
       )
     }
   )
+
+  // last_version_run was historically stored as Long in SharedPreferences and
+  // migrated verbatim into DataStore; newer code declared it as Int, crashing
+  // with ClassCastException when reading a migrated value. Normalize to Long.
+  internal fun lastVersionRunTypeMigration(): DataMigration<Preferences> =
+    object : DataMigration<Preferences> {
+      override suspend fun shouldMigrate(currentData: Preferences): Boolean {
+        val entry = currentData.asMap().entries
+          .firstOrNull { it.key.name == LAST_VERSION_RUN_KEY_NAME }
+        return entry != null && entry.value !is Long
+      }
+
+      override suspend fun migrate(currentData: Preferences): Preferences {
+        val mutable = currentData.toMutablePreferences()
+        val entry = currentData.asMap().entries
+          .firstOrNull { it.key.name == LAST_VERSION_RUN_KEY_NAME }
+        if (entry != null && entry.value !is Long) {
+          val asLong = (entry.value as? Number)?.toLong() ?: 0L
+          @Suppress("UNCHECKED_CAST")
+          mutable.remove(entry.key as Preferences.Key<Any>)
+          mutable[longPreferencesKey(LAST_VERSION_RUN_KEY_NAME)] = asLong
+        }
+        return mutable.toPreferences()
+      }
+
+      override suspend fun cleanUp() = Unit
+    }
 
   object PreferenceKeys {
     val THEME = stringPreferencesKey("theme_preference")
@@ -34,7 +62,7 @@ object SettingsDataStore {
     val LIBRARY_TRACK_DEFAULT_ACTION = stringPreferencesKey("mbrc.library_track_default")
     val ALBUM_ARTISTS_ONLY = booleanPreferencesKey("mbrc.settings.album_artist_only")
     val LAST_UPDATE_CHECK = longPreferencesKey("last_update_check")
-    val LAST_VERSION_RUN = intPreferencesKey("last_version_run")
+    val LAST_VERSION_RUN = longPreferencesKey(LAST_VERSION_RUN_KEY_NAME)
     val REQUIRED_UPDATE_CHECK = longPreferencesKey("update_required_check")
     val CLIENT_UUID = stringPreferencesKey("uuid")
     val HALF_STAR_RATING = booleanPreferencesKey("mbrc.settings.half_star_rating")
@@ -58,7 +86,7 @@ object SettingsDataStore {
     const val LIBRARY_TRACK_DEFAULT_ACTION = "now"
     const val ALBUM_ARTISTS_ONLY = false
     const val LAST_UPDATE_CHECK = 0L
-    const val LAST_VERSION_RUN = 0
+    const val LAST_VERSION_RUN = 0L
     const val REQUIRED_UPDATE_CHECK = 0L
     const val HALF_STAR_RATING = true
     const val SHOW_RATING_ON_PLAYER = false

--- a/feature/settings/src/main/kotlin/com/kelsos/mbrc/feature/settings/data/SettingsManagerDataStore.kt
+++ b/feature/settings/src/main/kotlin/com/kelsos/mbrc/feature/settings/data/SettingsManagerDataStore.kt
@@ -237,7 +237,7 @@ class SettingsManagerDataStore(
       preferences[PreferenceKeys.LAST_VERSION_RUN] ?: DefaultValues.LAST_VERSION_RUN
     }.first()
 
-    val currentVersion = appInfo.versionCode
+    val currentVersion = appInfo.versionCode.toLong()
 
     return if (lastVersionCode < currentVersion) {
       dataStore.edit { preferences ->

--- a/feature/settings/src/test/kotlin/com/kelsos/mbrc/feature/settings/data/LastVersionRunMigrationTest.kt
+++ b/feature/settings/src/test/kotlin/com/kelsos/mbrc/feature/settings/data/LastVersionRunMigrationTest.kt
@@ -1,0 +1,57 @@
+package com.kelsos.mbrc.feature.settings.data
+
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.mutablePreferencesOf
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class LastVersionRunMigrationTest {
+
+  private val migration = SettingsDataStore.lastVersionRunTypeMigration()
+
+  @Test
+  fun `shouldMigrate is false when key absent`() = runTest {
+    val prefs = mutablePreferencesOf().toPreferences()
+
+    assertThat(migration.shouldMigrate(prefs)).isFalse()
+  }
+
+  @Test
+  fun `shouldMigrate is false when value is already Long`() = runTest {
+    val prefs = mutablePreferencesOf(longPreferencesKey("last_version_run") to 127L)
+      .toPreferences()
+
+    assertThat(migration.shouldMigrate(prefs)).isFalse()
+  }
+
+  @Test
+  fun `shouldMigrate is true when value is Int`() = runTest {
+    val prefs = mutablePreferencesOf(intPreferencesKey("last_version_run") to 127)
+      .toPreferences()
+
+    assertThat(migration.shouldMigrate(prefs)).isTrue()
+  }
+
+  @Test
+  fun `migrate converts Int-typed value to Long`() = runTest {
+    val prefs = mutablePreferencesOf(intPreferencesKey("last_version_run") to 127)
+      .toPreferences()
+
+    val migrated = migration.migrate(prefs)
+
+    val entry = migrated.asMap().entries.single { it.key.name == "last_version_run" }
+    assertThat(entry.value is Long).isTrue()
+    assertThat(entry.value).isEqualTo(127L)
+  }
+
+  @Test
+  fun `migrate leaves prefs unchanged when key absent`() = runTest {
+    val prefs = mutablePreferencesOf().toPreferences()
+
+    val migrated = migration.migrate(prefs)
+
+    assertThat(migrated.asMap()).isEmpty()
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes Crashlytics issue `ee3e7ae3118c4eba3789d4019d422511` on 1.6.0-rc.2: `java.lang.ClassCastException: java.lang.Long cannot be cast to java.lang.Integer` in `SettingsManagerDataStore.checkShouldShowChangeLog` on startup.
- Root cause: the legacy app stored `last_version_run` via `putLong` in SharedPreferences (see pre-DataStore `SettingsManagerImpl`). `SharedPreferencesMigration` preserves the original primitive type, so for upgraded installs the value is `Long` in DataStore, but current code reads it via `intPreferencesKey` and casts to `Integer`.
- Switch `LAST_VERSION_RUN` to `longPreferencesKey` and add a one-shot `DataMigration<Preferences>` that rewrites any non-`Long` entry under `last_version_run` as `Long`. This covers both the legacy-`Long` case (migration is a no-op) and fresh installs on recent rc builds that stored it as `Int`.
- Cross-checked every other legacy SharedPreferences key against its current DataStore type — no other mismatches.
- Added `LastVersionRunMigrationTest` covering `shouldMigrate` for absent/Long/Int and the Int→Long rewrite.

## Test plan
- [x] `./gradlew :feature:settings:testDebugUnitTest --tests "*LastVersionRunMigrationTest*"`
- [x] `./gradlew lintKotlin detekt`
- [ ] Verify no recurrence of issue `ee3e7ae3...` on the next release candidate