### PR TITLE
chore: bump version to 1.6.0-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog
 -----------
 
 ## [Unreleased]
+
+## [1.6.0-rc.3] - 2026-04-19
 ### Fixed
 - Fixes a crash when opening the output selection (or any other API call) before a default connection is configured.
 - Fixes a crash when the plugin sends a cover protocol message with a null `cover` field.
@@ -255,7 +257,8 @@ Changelog
 - Removes the dialogs that used to appear on each new setup.
 
 
-[Unreleased]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0-rc.2...HEAD
+[Unreleased]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0-rc.3...HEAD
+[1.6.0-rc.3]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0-rc.2...v1.6.0-rc.3
 [1.6.0-rc.2]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0-rc.1...v1.6.0-rc.2
 [1.6.0-rc.1]: https://github.com/musicbeeremote/mbrc/compare/v1.5.1...v1.6.0-rc.1
 [1.5.1]: https://github.com/musicbeeremote/mbrc/compare/v1.5.0...v1.5.1

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -92,8 +92,8 @@ val buildTimeProvider = providers.provider {
   df.format(Date())
 }
 
-val appVersionName = "1.6.0-rc.2"
-val appVersionCode = 127
+val appVersionName = "1.6.0-rc.3"
+val appVersionCode = 128
 val minSDKVersion = 23
 val compileSDKVersion = 36
 

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <changelog>
   <version
-    version="Unreleased"
-    release="">
+    version="1.6.0-rc.3"
+    release="Apr 19, 2026">
     <bug>Fixes a crash when opening the output selection (or any other API call) before a default connection is configured.</bug>
     <bug>Fixes a crash when the plugin sends a cover protocol message with a null cover field.</bug>
     <bug>Fixes a startup crash for users upgrading from legacy versions caused by a type mismatch on the stored last-run version code.</bug>


### PR DESCRIPTION
## Summary
Release bump to 1.6.0-rc.3 (versionCode 128).

Includes the following fixes merged since rc.2:
- Crash when opening the output selection (or any other API call) before a default connection is configured.
- Crash when the plugin sends a cover protocol message with a null `cover` field.
- Startup crash for users upgrading from legacy versions caused by a type mismatch on the stored last-run version code (`last_version_run` was stored as `Long` in legacy SharedPreferences but read as `Int`).

## Test plan
- [ ] Tag `v1.6.0-rc.3` after merge and verify the Play release workflow runs
- [ ] Install upgrade from a legacy build to confirm the startup crash is gone