### PR TITLE
fix: don't crash on now-playing track with missing year field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog
 -----------
 
 ## [Unreleased]
+### Fixed
+- Fixes a crash on track change when the plugin omits the `year` field for tracks without a year tag.
 
 ## [1.6.0-rc.3] - 2026-04-19
 ### Fixed

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <changelog>
   <version
+    version="Unreleased"
+    release="">
+    <bug>Fixes a crash on track change when the plugin omits the year field for tracks without a year tag.</bug>
+  </version>
+  <version
     version="1.6.0-rc.3"
     release="Apr 19, 2026">
     <bug>Fixes a crash when opening the output selection (or any other API call) before a default connection is configured.</bug>

--- a/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/protocol/models/NowPlayingTrack.kt
+++ b/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/protocol/models/NowPlayingTrack.kt
@@ -6,13 +6,13 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class NowPlayingTrack(
   @Json(name = "artist")
-  val artist: String,
+  val artist: String = "",
   @Json(name = "album")
-  val album: String,
+  val album: String = "",
   @Json(name = "title")
-  val title: String,
+  val title: String = "",
   @Json(name = "year")
-  val year: String,
+  val year: String = "",
   @Json(name = "path")
-  val path: String
+  val path: String = ""
 )

--- a/core/networking/src/test/kotlin/com/kelsos/mbrc/core/networking/protocol/models/NowPlayingTrackTest.kt
+++ b/core/networking/src/test/kotlin/com/kelsos/mbrc/core/networking/protocol/models/NowPlayingTrackTest.kt
@@ -1,0 +1,46 @@
+package com.kelsos.mbrc.core.networking.protocol.models
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.moshi.Moshi
+import org.junit.Test
+
+class NowPlayingTrackTest {
+
+  private val adapter = Moshi.Builder().build().adapter(NowPlayingTrack::class.java)
+
+  @Test
+  fun `parses fully populated track`() {
+    val track = adapter.fromJson(
+      """{"artist":"a","album":"b","title":"c","year":"2024","path":"/p"}"""
+    )
+
+    assertThat(track).isNotNull()
+    assertThat(track!!.artist).isEqualTo("a")
+    assertThat(track.album).isEqualTo("b")
+    assertThat(track.title).isEqualTo("c")
+    assertThat(track.year).isEqualTo("2024")
+    assertThat(track.path).isEqualTo("/p")
+  }
+
+  @Test
+  fun `parses track when year field is missing`() {
+    val track = adapter.fromJson(
+      """{"artist":"a","album":"b","title":"c","path":"/p"}"""
+    )
+
+    assertThat(track).isNotNull()
+    assertThat(track!!.year).isEmpty()
+  }
+
+  @Test
+  fun `parses track when all fields are missing`() {
+    val track = adapter.fromJson("""{}""")
+
+    assertThat(track).isNotNull()
+    assertThat(track!!.artist).isEmpty()
+    assertThat(track.album).isEmpty()
+    assertThat(track.title).isEmpty()
+    assertThat(track.year).isEmpty()
+    assertThat(track.path).isEmpty()
+  }
+}


### PR DESCRIPTION
## Summary
- Moshi's generated adapter crashes with `Required value 'year' missing at $` when the plugin omits the `year` key on track change (Crashlytics issue `00fe452d6d5ef11aa0a984d9098d95fd`, v1.6.0-rc.3).
- Plugin v1.4.1 serializes `NowPlayingTrackV2` via ServiceStack.Text, which omits null fields by default; the Year tag is not normalized on the plugin side, so tracks without a year produce a missing key on the wire.
- Default all `NowPlayingTrack` string fields to `""` so absent keys are tolerated, and add regression tests.

## Test plan
- [x] `./gradlew :core:networking:testDebugUnitTest --tests NowPlayingTrackTest`
- [x] `./gradlew formatKotlin lintKotlin`