### PR TITLE
fix: open app from widget via actionStartActivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 ## [Unreleased]
 ### Fixed
 - Fixes a crash on track change when the plugin omits the `year` field for tracks without a year tag.
+- Fixes a home screen widget crash when tapping the widget to open the app, by launching the activity directly instead of routing through a Glance action callback.
 
 ## [1.6.0-rc.3] - 2026-04-19
 ### Fixed

--- a/app/src/main/kotlin/com/kelsos/mbrc/adapters/RemoteViewIntentBuilderImpl.kt
+++ b/app/src/main/kotlin/com/kelsos/mbrc/adapters/RemoteViewIntentBuilderImpl.kt
@@ -43,7 +43,10 @@ class RemoteViewIntentBuilderImpl :
 
   override fun getLaunchPendingIntent(context: Context): PendingIntent {
     val flag = FLAG_UPDATE_CURRENT or FLAG_IMMUTABLE
-    val intent = Intent(context, MainActivity::class.java)
+    val intent = getLaunchIntent(context)
     return getActivity(context, RemoteIntentCode.Open.code, intent, flag)
   }
+
+  override fun getLaunchIntent(context: Context): Intent = Intent(context, MainActivity::class.java)
+    .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
 }

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -4,6 +4,7 @@
     version="Unreleased"
     release="">
     <bug>Fixes a crash on track change when the plugin omits the year field for tracks without a year tag.</bug>
+    <bug>Fixes a home screen widget crash when tapping the widget to open the app, by launching the activity directly instead of routing through a Glance action callback.</bug>
   </version>
   <version
     version="1.6.0-rc.3"

--- a/core/platform/src/main/kotlin/com/kelsos/mbrc/core/platform/intents/AppLauncher.kt
+++ b/core/platform/src/main/kotlin/com/kelsos/mbrc/core/platform/intents/AppLauncher.kt
@@ -2,6 +2,7 @@ package com.kelsos.mbrc.core.platform.intents
 
 import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 
 /**
  * Abstraction for launching the main app activity.
@@ -9,4 +10,6 @@ import android.content.Context
  */
 interface AppLauncher {
   fun getLaunchPendingIntent(context: Context): PendingIntent
+
+  fun getLaunchIntent(context: Context): Intent
 }

--- a/feature/widgets/src/main/kotlin/com/kelsos/mbrc/feature/widgets/glance/MusicWidgetContent.kt
+++ b/feature/widgets/src/main/kotlin/com/kelsos/mbrc/feature/widgets/glance/MusicWidgetContent.kt
@@ -1,5 +1,6 @@
 package com.kelsos.mbrc.feature.widgets.glance
 
+import android.content.Intent
 import android.graphics.Bitmap
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
@@ -12,6 +13,7 @@ import androidx.glance.ImageProvider
 import androidx.glance.action.Action
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.action.actionRunCallback
+import androidx.glance.appwidget.action.actionStartActivity
 import androidx.glance.appwidget.cornerRadius
 import androidx.glance.background
 import androidx.glance.layout.Alignment
@@ -43,11 +45,11 @@ data class WidgetActions(
   val onOpenApp: Action
 ) {
   companion object {
-    val Default = WidgetActions(
+    fun default(openAppIntent: Intent) = WidgetActions(
       onPrevious = actionRunCallback<PreviousTrackAction>(),
       onPlayPause = actionRunCallback<PlayPauseAction>(),
       onNext = actionRunCallback<NextTrackAction>(),
-      onOpenApp = actionRunCallback<OpenAppAction>()
+      onOpenApp = actionStartActivity(openAppIntent)
     )
 
     /**
@@ -85,7 +87,7 @@ private const val SMALL_WIDGET_HEIGHT = 72
  * Shows: Album cover, title, artist, album, and playback controls.
  */
 @Composable
-fun NormalWidgetContent(state: WidgetState, actions: WidgetActions = WidgetActions.Default) {
+fun NormalWidgetContent(state: WidgetState, actions: WidgetActions) {
   Row(
     modifier = GlanceModifier
       .fillMaxWidth()
@@ -97,8 +99,7 @@ fun NormalWidgetContent(state: WidgetState, actions: WidgetActions = WidgetActio
     // Album cover
     AlbumCover(
       bitmap = state.coverBitmap,
-      size = NORMAL_WIDGET_HEIGHT.dp,
-      modifier = GlanceModifier.clickable(actions.onOpenApp)
+      size = NORMAL_WIDGET_HEIGHT.dp
     )
 
     // Track info and controls
@@ -154,7 +155,7 @@ fun NormalWidgetContent(state: WidgetState, actions: WidgetActions = WidgetActio
  * Shows: Album cover, title - artist, and playback controls.
  */
 @Composable
-fun SmallWidgetContent(state: WidgetState, actions: WidgetActions = WidgetActions.Default) {
+fun SmallWidgetContent(state: WidgetState, actions: WidgetActions) {
   Row(
     modifier = GlanceModifier
       .fillMaxWidth()
@@ -166,8 +167,7 @@ fun SmallWidgetContent(state: WidgetState, actions: WidgetActions = WidgetAction
     // Album cover
     AlbumCover(
       bitmap = state.coverBitmap,
-      size = SMALL_WIDGET_HEIGHT.dp,
-      modifier = GlanceModifier.clickable(actions.onOpenApp)
+      size = SMALL_WIDGET_HEIGHT.dp
     )
 
     // Track info and controls

--- a/feature/widgets/src/main/kotlin/com/kelsos/mbrc/feature/widgets/glance/NormalWidget.kt
+++ b/feature/widgets/src/main/kotlin/com/kelsos/mbrc/feature/widgets/glance/NormalWidget.kt
@@ -9,22 +9,30 @@ import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.glance.appwidget.provideContent
 import androidx.glance.currentState
 import androidx.glance.state.GlanceStateDefinition
+import com.kelsos.mbrc.core.platform.intents.AppLauncher
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
 /**
  * Normal size music widget (128dp height).
  * Shows album cover, track title, artist, album, and playback controls.
  */
-class NormalWidget : GlanceAppWidget() {
+class NormalWidget :
+  GlanceAppWidget(),
+  KoinComponent {
+
+  private val appLauncher: AppLauncher by inject()
 
   override val stateDefinition: GlanceStateDefinition<Preferences> = WidgetGlanceStateDefinition
 
   override suspend fun provideGlance(context: Context, id: GlanceId) {
+    val actions = WidgetActions.default(appLauncher.getLaunchIntent(context))
     provideContent {
       val prefs = currentState<Preferences>()
       val state = WidgetGlanceStateDefinition.preferencesToWidgetState(context, prefs)
 
       GlanceTheme {
-        NormalWidgetContent(state)
+        NormalWidgetContent(state, actions)
       }
     }
   }

--- a/feature/widgets/src/main/kotlin/com/kelsos/mbrc/feature/widgets/glance/SmallWidget.kt
+++ b/feature/widgets/src/main/kotlin/com/kelsos/mbrc/feature/widgets/glance/SmallWidget.kt
@@ -9,22 +9,30 @@ import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.glance.appwidget.provideContent
 import androidx.glance.currentState
 import androidx.glance.state.GlanceStateDefinition
+import com.kelsos.mbrc.core.platform.intents.AppLauncher
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
 /**
  * Small size music widget (72dp height).
  * Shows album cover, combined title-artist, and playback controls.
  */
-class SmallWidget : GlanceAppWidget() {
+class SmallWidget :
+  GlanceAppWidget(),
+  KoinComponent {
+
+  private val appLauncher: AppLauncher by inject()
 
   override val stateDefinition: GlanceStateDefinition<Preferences> = WidgetGlanceStateDefinition
 
   override suspend fun provideGlance(context: Context, id: GlanceId) {
+    val actions = WidgetActions.default(appLauncher.getLaunchIntent(context))
     provideContent {
       val prefs = currentState<Preferences>()
       val state = WidgetGlanceStateDefinition.preferencesToWidgetState(context, prefs)
 
       GlanceTheme {
-        SmallWidgetContent(state)
+        SmallWidgetContent(state, actions)
       }
     }
   }

--- a/feature/widgets/src/main/kotlin/com/kelsos/mbrc/feature/widgets/glance/WidgetActions.kt
+++ b/feature/widgets/src/main/kotlin/com/kelsos/mbrc/feature/widgets/glance/WidgetActions.kt
@@ -5,10 +5,7 @@ import android.content.Intent
 import androidx.glance.GlanceId
 import androidx.glance.action.ActionParameters
 import androidx.glance.appwidget.action.ActionCallback
-import com.kelsos.mbrc.core.platform.intents.AppLauncher
 import com.kelsos.mbrc.core.platform.intents.MediaIntentActions
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 
 /**
  * Action callback for play/pause button.
@@ -46,24 +43,5 @@ class PreviousTrackAction : ActionCallback {
     parameters: ActionParameters
   ) {
     context.sendBroadcast(Intent(MediaIntentActions.PREVIOUS_PRESSED))
-  }
-}
-
-/**
- * Action callback to open the main app.
- * Uses AppLauncher from Koin to get the app launch intent.
- */
-class OpenAppAction :
-  ActionCallback,
-  KoinComponent {
-  private val appLauncher: AppLauncher by inject()
-
-  override suspend fun onAction(
-    context: Context,
-    glanceId: GlanceId,
-    parameters: ActionParameters
-  ) {
-    val pendingIntent = appLauncher.getLaunchPendingIntent(context)
-    pendingIntent.send()
   }
 }


### PR DESCRIPTION
## Summary
- Home screen widgets were crashing with `IllegalArgumentException: List adapter activity trampoline invoked without specifying target intent` (Crashlytics issue `babbf348be7e1a6e02bf8b613922247b`, seen on both `ActionTrampolineActivity` and `InvisibleActionTrampolineActivity`).
- The crash comes from Glance's trampoline check at `ActionTrampoline.kt:93` when the trampoline's target-intent extra is missing — a known failure mode for `ActionCallback`-based open-app flows, especially after app updates or process kills.
- This PR switches the widget's open-app click to `actionStartActivity` with an explicit `MainActivity` intent, skipping the trampoline entirely for that path. Playback broadcast callbacks (`PlayPauseAction`, `NextTrackAction`, `PreviousTrackAction`) are left unchanged since they only dispatch broadcasts.
- Adds `AppLauncher.getLaunchIntent(Context): Intent` so `:feature:widgets` can obtain the `MainActivity` intent without depending on `:app`.

Note: this is a targeted mitigation for the most common path (opening the app). The broadcast callbacks could theoretically hit the same Glance bug, but all observed traces were on the open-app path.

## Test plan
- [x] `./gradlew :feature:widgets:test` — green
- [x] `./gradlew :feature:widgets:compileDebugKotlin :app:compileGithubDebugKotlin` — green
- [x] Installed on device; widget opens the app when tapped
- [ ] Monitor Crashlytics `babbf348…` for regression/recurrence after release