### PR TITLE
fix: don't crash when broadcast action throws

### DIFF
--- a/app/src/main/kotlin/com/kelsos/mbrc/adapters/ProtocolActionAdapters.kt
+++ b/app/src/main/kotlin/com/kelsos/mbrc/adapters/ProtocolActionAdapters.kt
@@ -111,7 +111,11 @@ class NowPlayingHandlerImpl(private val repository: NowPlayingRepository) : NowP
   }
 
   override suspend fun refreshFromRemote() {
-    repository.getRemote()
+    runCatching {
+      repository.getRemote()
+    }.onFailure { e ->
+      Timber.v(e, "Failed to refresh now playing list from remote")
+    }
   }
 }
 

--- a/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/MessageHandler.kt
+++ b/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/MessageHandler.kt
@@ -13,6 +13,7 @@ import com.kelsos.mbrc.core.networking.protocol.base.Protocol
 import com.kelsos.mbrc.core.networking.protocol.base.ProtocolAction
 import com.kelsos.mbrc.core.networking.protocol.base.ProtocolPayload
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -138,9 +139,16 @@ class MessageHandlerImpl(
   }
 
   private suspend fun execute(event: MessageEvent) {
-    get(event.type)
-      .onSuccess { it.execute(event) }
-      .onFailure { Timber.e(it, "Failed to execute command for $event") }
+    val action = get(event.type)
+      .onFailure { Timber.e(it, "Failed to resolve command for $event") }
+      .getOrNull() ?: return
+    try {
+      action.execute(event)
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Exception) {
+      Timber.e(e, "Failed to execute command for $event")
+    }
   }
 
   private fun get(context: Protocol) = runCatching {


### PR DESCRIPTION
## Summary
- `NowPlayingHandlerImpl.refreshFromRemote()` let `NoDefaultConnectionException` (an `IOException` from `RequestManager.connect`) propagate out, crashing the listener coroutine (Crashlytics issue `a8170993f84679796659ac33189bc1e0`, 1.6.0-rc.3).
- Root cause in `MessageHandler.execute`: `it.execute(event)` was invoked inside `Result.onSuccess`, which does NOT catch exceptions thrown from the lambda body — so any action throwable escaped.
- Swallow + log the refresh failure in the adapter (same pattern as `requestTrackDetails`), and harden `MessageHandler.execute` with a try/catch that rethrows `CancellationException`, so a misbehaving broadcast action can no longer take down the app.

## Test plan
- [ ] Manually trigger a now-playing list broadcast while the default connection is absent; verify the app logs but does not crash.
- [ ] Normal connected flow still refreshes the now-playing list on broadcast.
- [ ] `./gradlew test` passes.