### PR TITLE
Changelog entry for broadcast-action crash fix + upload Play mapping.txt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,12 @@ jobs:
           name: play-aab
           path: app/build/outputs/bundle/playRelease/*.aab
 
+      - name: Upload Play mapping
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: play-mapping
+          path: app/build/outputs/mapping/playRelease/mapping.txt
+
   attest:
     needs: build
     runs-on: ubuntu-latest
@@ -180,6 +186,15 @@ jobs:
           name: play-aab
           path: artifacts/aab
 
+      - name: Download Play mapping
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: play-mapping
+          path: artifacts/mapping
+
+      - name: Rename mapping with version
+        run: mv artifacts/mapping/mapping.txt "artifacts/mapping/mapping-${{ github.ref_name }}.txt"
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -206,4 +221,5 @@ jobs:
           )" \
             artifacts/apk/*.apk \
             artifacts/play-apk/*.apk \
-            artifacts/aab/*.aab
+            artifacts/aab/*.aab \
+            artifacts/mapping/mapping-*.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 ### Fixed
 - Fixes a crash on track change when the plugin omits the `year` field for tracks without a year tag.
 - Fixes a home screen widget crash when tapping the widget to open the app, by launching the activity directly instead of routing through a Glance action callback.
+- Fixes a crash when a broadcast action throws, by catching exceptions in the message handler and swallowing the no-default-connection error during now-playing refresh.
 
 ## [1.6.0-rc.3] - 2026-04-19
 ### Fixed

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -5,6 +5,7 @@
     release="">
     <bug>Fixes a crash on track change when the plugin omits the year field for tracks without a year tag.</bug>
     <bug>Fixes a home screen widget crash when tapping the widget to open the app, by launching the activity directly instead of routing through a Glance action callback.</bug>
+    <bug>Fixes a crash when a broadcast action throws, by catching exceptions in the message handler and swallowing the no-default-connection error during now-playing refresh.</bug>
   </version>
   <version
     version="1.6.0-rc.3"


### PR DESCRIPTION
## Summary
- Adds the broadcast-action crash fix (e42e8e6a) to both `CHANGELOG.md` and the in-app `changelog.xml` under Unreleased.
- Uploads the Play release `mapping.txt` as a workflow artifact so it can be grabbed and uploaded to the Play Console for deobfuscated crash reports.

## Test plan
- [ ] Verify changelog entries render correctly in the What's New screen.
- [ ] On the next tagged release, confirm the `play-mapping` artifact appears in the workflow run and contains `mapping.txt`.