### PR TITLE
chore: bump version to 1.6.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,17 @@ Changelog
 -----------
 
 ## [Unreleased]
+
+## [1.6.0-rc.4] - 2026-04-22
 ### Fixed
 - Fixes a crash on track change when the plugin omits the `year` field for tracks without a year tag.
 - Fixes a home screen widget crash when tapping the widget to open the app, by launching the activity directly instead of routing through a Glance action callback.
 - Fixes a crash when a broadcast action throws, by catching exceptions in the message handler and swallowing the no-default-connection error during now-playing refresh.
+- Fixes the app License screen failing to load because the bundled `LICENSE.txt` asset was missing from the APK.
+
+### Changed
+- Updates `aboutlibraries` to 14.0.1 and bumps other minor/patch dependencies (Firebase BOM, Koin, androidx.annotation, Crashlytics plugin).
+- Pins GitHub Actions to newer digests (upload-artifact, setup-android, codeql-action, gradle/actions).
 
 ## [1.6.0-rc.3] - 2026-04-19
 ### Fixed
@@ -261,7 +268,8 @@ Changelog
 - Removes the dialogs that used to appear on each new setup.
 
 
-[Unreleased]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0-rc.3...HEAD
+[Unreleased]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0-rc.4...HEAD
+[1.6.0-rc.4]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0-rc.3...v1.6.0-rc.4
 [1.6.0-rc.3]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0-rc.2...v1.6.0-rc.3
 [1.6.0-rc.2]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0-rc.1...v1.6.0-rc.2
 [1.6.0-rc.1]: https://github.com/musicbeeremote/mbrc/compare/v1.5.1...v1.6.0-rc.1

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -92,8 +92,8 @@ val buildTimeProvider = providers.provider {
   df.format(Date())
 }
 
-val appVersionName = "1.6.0-rc.3"
-val appVersionCode = 128
+val appVersionName = "1.6.0-rc.4"
+val appVersionCode = 129
 val minSDKVersion = 23
 val compileSDKVersion = 36
 

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -3,9 +3,14 @@
   <version
     version="Unreleased"
     release="">
+  </version>
+  <version
+    version="1.6.0-rc.4"
+    release="Apr 22, 2026">
     <bug>Fixes a crash on track change when the plugin omits the year field for tracks without a year tag.</bug>
     <bug>Fixes a home screen widget crash when tapping the widget to open the app, by launching the activity directly instead of routing through a Glance action callback.</bug>
     <bug>Fixes a crash when a broadcast action throws, by catching exceptions in the message handler and swallowing the no-default-connection error during now-playing refresh.</bug>
+    <bug>Fixes the app License screen failing to load because the bundled LICENSE.txt asset was missing from the APK.</bug>
   </version>
   <version
     version="1.6.0-rc.3"


### PR DESCRIPTION
## Summary

Bumps to 1.6.0-rc.4 (versionCode 129). Aggregates the fixes and dependency refreshes that landed on main since rc.3.

### Fixed
- Crash on track change when the plugin omits the \`year\` field.
- Home screen widget crash when tapping the widget to open the app.
- Crash when a broadcast action throws.
- App License screen failing to load because the bundled \`LICENSE.txt\` asset was missing from the APK.

### Changed
- \`aboutlibraries\` 14.0.1 and minor/patch dependency bumps (Firebase BOM, Koin, androidx.annotation, Crashlytics plugin).
- GitHub Actions pinned to newer digests.

## Test plan

- [x] \`./gradlew :app:assembleGithubDebug formatKotlin lintKotlin\` passes.
- [ ] CI green.