### PR TITLE
ci: zip R8 mapping before attaching to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,8 +192,11 @@ jobs:
           name: play-mapping
           path: artifacts/mapping
 
-      - name: Rename mapping with version
-        run: mv artifacts/mapping/mapping.txt "artifacts/mapping/mapping-${{ github.ref_name }}.txt"
+      - name: Compress mapping with version
+        run: |
+          mv artifacts/mapping/mapping.txt "artifacts/mapping/mapping-${{ github.ref_name }}.txt"
+          (cd artifacts/mapping && zip -9 "mapping-${{ github.ref_name }}.zip" "mapping-${{ github.ref_name }}.txt")
+          rm "artifacts/mapping/mapping-${{ github.ref_name }}.txt"
 
       - name: Create GitHub Release
         env:
@@ -222,4 +225,4 @@ jobs:
             artifacts/apk/*.apk \
             artifacts/play-apk/*.apk \
             artifacts/aab/*.aab \
-            artifacts/mapping/mapping-*.txt
+            artifacts/mapping/mapping-*.zip


### PR DESCRIPTION
## Summary
- The uncompressed `mapping.txt` attached to GitHub releases is ~90MB
- Zip it with max compression (`-9`) before upload; text compresses very well so the asset shrinks substantially
- Release asset glob updated from `mapping-*.txt` to `mapping-*.zip`

## Test plan
- [ ] Next tagged release produces `mapping-v<version>.zip` as a release asset
- [ ] Zip contains `mapping-v<version>.txt` and unzips cleanly for deobfuscation