### PR TITLE
fix(now-playing): unbreak queue paging, empty-state refresh, and cross-page drag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog
 -----------
 
 ## [Unreleased]
+### Fixed
+- Fixes the now playing queue capping at 100 items: only the first page ever loaded because `LazyPagingItems` was iterated indirectly. The queue now enables placeholders and iterates `LazyPagingItems` directly so Paging 3 keeps loading subsequent pages on scroll.
+- Fixes pull-to-refresh not triggering when the now playing queue is empty by wrapping the empty/loading/error states in a vertically scrollable container.
+- Fixes drag-and-drop reorder being snapped back to the server order when a new page lands mid-drag, and lets users reorder across page boundaries by guarding mid-drag refreshes with a settle window and resolving the source index against the displayed list.
 
 ## [1.6.0-rc.4] - 2026-04-22
 ### Fixed

--- a/app/src/main/kotlin/com/kelsos/mbrc/adapters/ProtocolActionAdapters.kt
+++ b/app/src/main/kotlin/com/kelsos/mbrc/adapters/ProtocolActionAdapters.kt
@@ -14,6 +14,7 @@ import com.kelsos.mbrc.core.common.state.TrackInfo
 import com.kelsos.mbrc.core.common.state.TrackRating
 import com.kelsos.mbrc.core.common.utilities.coroutines.AppCoroutineDispatchers
 import com.kelsos.mbrc.core.networking.api.PlaybackApi
+import com.kelsos.mbrc.core.networking.protocol.SelfMutationTracker
 import com.kelsos.mbrc.core.networking.protocol.actions.CoverHandler
 import com.kelsos.mbrc.core.networking.protocol.actions.NowPlayingHandler
 import com.kelsos.mbrc.core.networking.protocol.actions.PlayerStateHandler
@@ -105,12 +106,19 @@ class TrackChangeNotifierImpl(
 /**
  * Adapts [NowPlayingRepository] to [NowPlayingHandler] interface.
  */
-class NowPlayingHandlerImpl(private val repository: NowPlayingRepository) : NowPlayingHandler {
+class NowPlayingHandlerImpl(
+  private val repository: NowPlayingRepository,
+  private val selfMutationTracker: SelfMutationTracker
+) : NowPlayingHandler {
   override suspend fun removeTrack(position: Int) {
     repository.remove(position)
   }
 
   override suspend fun refreshFromRemote() {
+    if (selfMutationTracker.wasRecentlyMarked()) {
+      Timber.v("skipping refresh — recent self-initiated mutation")
+      return
+    }
     runCatching {
       repository.getRemote()
     }.onFailure { e ->

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -3,6 +3,9 @@
   <version
     version="Unreleased"
     release="">
+    <bug>Fixes the now playing queue capping at 100 items so the full queue is reachable on scroll.</bug>
+    <bug>Fixes pull-to-refresh not triggering when the now playing queue is empty.</bug>
+    <bug>Fixes drag-and-drop reorder snapping back when a new page loaded mid-drag, and now lets users reorder across page boundaries.</bug>
   </version>
   <version
     version="1.6.0-rc.4"

--- a/app/src/test/kotlin/com/kelsos/mbrc/adapters/NowPlayingHandlerImplTest.kt
+++ b/app/src/test/kotlin/com/kelsos/mbrc/adapters/NowPlayingHandlerImplTest.kt
@@ -1,0 +1,56 @@
+package com.kelsos.mbrc.adapters
+
+import com.kelsos.mbrc.core.networking.protocol.SelfMutationTracker
+import com.kelsos.mbrc.feature.playback.nowplaying.NowPlayingRepository
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class NowPlayingHandlerImplTest {
+  private val repository: NowPlayingRepository = mockk(relaxed = true)
+  private val tracker: SelfMutationTracker = mockk()
+  private val handler = NowPlayingHandlerImpl(repository, tracker)
+
+  @Test
+  fun `refreshFromRemote skips repository when tracker is recently marked`() = runTest {
+    every { tracker.wasRecentlyMarked() } returns true
+
+    handler.refreshFromRemote()
+
+    coVerify(exactly = 0) { repository.getRemote(any()) }
+  }
+
+  @Test
+  fun `refreshFromRemote calls repository when tracker is not recently marked`() = runTest {
+    every { tracker.wasRecentlyMarked() } returns false
+    coEvery { repository.getRemote(any()) } just Runs
+
+    handler.refreshFromRemote()
+
+    coVerify(exactly = 1) { repository.getRemote(any()) }
+  }
+
+  @Test
+  fun `refreshFromRemote swallows repository failures`() = runTest {
+    every { tracker.wasRecentlyMarked() } returns false
+    coEvery { repository.getRemote(any()) } throws RuntimeException("boom")
+
+    handler.refreshFromRemote()
+
+    coVerify(exactly = 1) { repository.getRemote(any()) }
+  }
+
+  @Test
+  fun `removeTrack delegates to repository regardless of tracker state`() = runTest {
+    coEvery { repository.remove(any()) } just Runs
+
+    handler.removeTrack(7)
+
+    coVerify(exactly = 1) { repository.remove(7) }
+  }
+}

--- a/core/data/src/main/kotlin/com/kelsos/mbrc/core/data/PagingHelper.kt
+++ b/core/data/src/main/kotlin/com/kelsos/mbrc/core/data/PagingHelper.kt
@@ -10,11 +10,12 @@ import kotlinx.coroutines.flow.map
 
 fun <T : Any, I : Any> paged(
   pagingSourceFactory: () -> PagingSource<Int, T>,
+  enablePlaceholders: Boolean = false,
   transform: (value: T) -> I
 ): Flow<PagingData<I>> {
   val config =
     PagingConfig(
-      enablePlaceholders = false,
+      enablePlaceholders = enablePlaceholders,
       pageSize = 50,
       prefetchDistance = 25,
       initialLoadSize = 100

--- a/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/NetworkingModule.kt
+++ b/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/NetworkingModule.kt
@@ -20,6 +20,9 @@ import com.kelsos.mbrc.core.networking.data.SerializationAdapter
 import com.kelsos.mbrc.core.networking.data.SerializationAdapterImpl
 import com.kelsos.mbrc.core.networking.discovery.RemoteServiceDiscovery
 import com.kelsos.mbrc.core.networking.discovery.RemoteServiceDiscoveryImpl
+import com.kelsos.mbrc.core.networking.protocol.Clock
+import com.kelsos.mbrc.core.networking.protocol.SelfMutationConfig
+import com.kelsos.mbrc.core.networking.protocol.SelfMutationTracker
 import com.kelsos.mbrc.core.networking.protocol.actions.ProtocolPingHandle
 import com.kelsos.mbrc.core.networking.protocol.actions.ProtocolVersionUpdate
 import com.kelsos.mbrc.core.networking.protocol.actions.SimpleLogCommand
@@ -77,6 +80,9 @@ val networkingModule = module {
   singleOf(::DeserializationAdapterImpl) { bind<DeserializationAdapter>() }
 
   // Core networking
+  single<Clock> { Clock { System.currentTimeMillis() } }
+  single { SelfMutationConfig() }
+  singleOf(::SelfMutationTracker)
   singleOf(::ApiBase)
   singleOf(::RequestManagerImpl) { bind<RequestManager>() }
   singleOf(::SocketActivityChecker)

--- a/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/protocol/SelfMutationTracker.kt
+++ b/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/protocol/SelfMutationTracker.kt
@@ -1,0 +1,45 @@
+package com.kelsos.mbrc.core.networking.protocol
+
+fun interface Clock {
+  fun now(): Long
+}
+
+data class SelfMutationConfig(val windowMs: Long = DEFAULT_WINDOW_MS) {
+  companion object {
+    const val DEFAULT_WINDOW_MS: Long = 3_000L
+  }
+}
+
+/**
+ * Tracks recent self-initiated mutations to the now-playing list (move, remove)
+ * so the broadcast handler can skip the redundant `getRemote()` refresh that
+ * would otherwise fire a second `PagingSource` invalidation right after our
+ * own local DB write — that cascade is what made the queue view jump back to
+ * the loaded-page boundary after a drop.
+ *
+ * TODO: replace with a delta-sync in `NowPlayingRepository.getRemote()` that
+ *  only invalidates rows that actually changed. The wall-clock window here is
+ *  a defense-in-depth band-aid: it suppresses *all* refreshes during the window,
+ *  not just self-caused ones, which is correct in practice but coarser than it
+ *  needs to be.
+ */
+class SelfMutationTracker(private val clock: Clock, config: SelfMutationConfig) {
+  private val windowMs: Long = config.windowMs
+
+  @Volatile
+  private var lastMarkedAt: Long = NEVER
+
+  fun mark() {
+    lastMarkedAt = clock.now()
+  }
+
+  fun wasRecentlyMarked(): Boolean {
+    val marked = lastMarkedAt
+    if (marked == NEVER) return false
+    return clock.now() - marked < windowMs
+  }
+
+  private companion object {
+    const val NEVER: Long = Long.MIN_VALUE
+  }
+}

--- a/core/networking/src/test/kotlin/com/kelsos/mbrc/core/networking/protocol/SelfMutationTrackerTest.kt
+++ b/core/networking/src/test/kotlin/com/kelsos/mbrc/core/networking/protocol/SelfMutationTrackerTest.kt
@@ -1,0 +1,52 @@
+package com.kelsos.mbrc.core.networking.protocol
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class SelfMutationTrackerTest {
+
+  private fun tracker(clock: Clock, windowMs: Long = 100L) =
+    SelfMutationTracker(clock, SelfMutationConfig(windowMs = windowMs))
+
+  @Test
+  fun `wasRecentlyMarked returns false before any mark`() {
+    val tracker = tracker(clock = { 1_000L })
+
+    assertThat(tracker.wasRecentlyMarked()).isFalse()
+  }
+
+  @Test
+  fun `wasRecentlyMarked returns true within the window after mark`() {
+    var now = 1_000L
+    val tracker = tracker(clock = { now })
+
+    tracker.mark()
+    now = 1_050L
+
+    assertThat(tracker.wasRecentlyMarked()).isTrue()
+  }
+
+  @Test
+  fun `wasRecentlyMarked returns false once the window elapses`() {
+    var now = 1_000L
+    val tracker = tracker(clock = { now })
+
+    tracker.mark()
+    now = 1_101L
+
+    assertThat(tracker.wasRecentlyMarked()).isFalse()
+  }
+
+  @Test
+  fun `mark resets the window so a later broadcast is still skipped`() {
+    var now = 1_000L
+    val tracker = tracker(clock = { now })
+
+    tracker.mark()
+    now = 1_080L
+    tracker.mark()
+    now = 1_170L
+
+    assertThat(tracker.wasRecentlyMarked()).isTrue()
+  }
+}

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -16,6 +16,11 @@ android {
     compose = true
   }
 
+  testOptions {
+    unitTests.isReturnDefaultValues = true
+    unitTests.isIncludeAndroidResources = true
+  }
+
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
@@ -35,4 +40,13 @@ dependencies {
   implementation(libs.bundles.androidx.compose)
   implementation(libs.google.material)
   implementation(libs.androidx.paging.compose)
+
+  testImplementation(libs.androidx.test.core)
+  testImplementation(libs.androidx.test.runner)
+  testImplementation(libs.androidx.test.junit)
+  testImplementation(libs.truth)
+  testImplementation(libs.kotlin.coroutines.test)
+  testImplementation(libs.robolectric)
+  testImplementation(libs.androidx.compose.ui.test.junit4)
+  debugImplementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/core/ui/src/main/kotlin/com/kelsos/mbrc/core/ui/compose/DragDropState.kt
+++ b/core/ui/src/main/kotlin/com/kelsos/mbrc/core/ui/compose/DragDropState.kt
@@ -1,8 +1,5 @@
 package com.kelsos.mbrc.core.ui.compose
 
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.spring
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.lazy.LazyListItemInfo
@@ -21,6 +18,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.pointerInput
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 /**
@@ -32,7 +30,8 @@ import kotlinx.coroutines.launch
  * androidx/compose/foundation/demos/LazyColumnDragAndDropDemo.kt
  *
  * @param state The LazyListState of the LazyColumn
- * @param scope CoroutineScope for animations and scroll operations
+ * @param scope CoroutineScope used to clear the post-drop permutation once
+ * the new paging data has had a chance to land
  * @param onMove Callback invoked when items are swapped during drag
  * @param onDragEnd Callback invoked when drag operation completes (for syncing to server)
  */
@@ -45,52 +44,83 @@ class DragDropState(
   var draggingItemIndex by mutableStateOf<Int?>(null)
     private set
 
+  /**
+   * True between drag-release and the post-drop paging emission. While set, the
+   * permutation indices stay populated so the dropped item remains rendered at
+   * its target slot, avoiding a visible snap-back to the source position before
+   * `dao.move` propagates through paging.
+   */
+  var isSettling by mutableStateOf(false)
+    private set
+
+  /**
+   * Position of the dragged item at the moment the drag started. Stays fixed
+   * for the entire drag (unlike [draggingItemIndex], which tracks the current
+   * displayed position). Used by the renderer to compute the displayed
+   * permutation without mutating the underlying data source.
+   */
+  var dragSourceIndex by mutableStateOf<Int?>(null)
+    private set
+
   internal val scrollChannel = Channel<Float>()
 
   private var draggingItemDraggedDelta by mutableFloatStateOf(0f)
   private var draggingItemInitialOffset by mutableIntStateOf(0)
+  private var settleVersion by mutableIntStateOf(0)
 
   val draggingItemOffset: Float
-    get() = draggingItemLayoutInfo?.let { item ->
-      draggingItemInitialOffset + draggingItemDraggedDelta - item.offset
-    } ?: 0f
+    get() = if (isSettling) {
+      0f
+    } else {
+      draggingItemLayoutInfo?.let { item ->
+        draggingItemInitialOffset + draggingItemDraggedDelta - item.offset
+      } ?: 0f
+    }
 
   private val draggingItemLayoutInfo: LazyListItemInfo?
     get() = state.layoutInfo.visibleItemsInfo.firstOrNull { it.index == draggingItemIndex }
 
-  var previousIndexOfDraggedItem by mutableStateOf<Int?>(null)
-    private set
-
-  var previousItemOffset = Animatable(0f)
-    private set
-
   internal fun onDragStart(offset: Offset) {
+    // Invalidate any pending settle from a previous drop so it doesn't clobber
+    // the new drag's state.
+    settleVersion++
+    isSettling = false
     state.layoutInfo.visibleItemsInfo
       .firstOrNull { item -> offset.y.toInt() in item.offset..item.offset + item.size }
       ?.also {
         draggingItemIndex = it.index
+        dragSourceIndex = it.index
         draggingItemInitialOffset = it.offset
       }
   }
 
   internal fun onDragInterrupted() {
-    if (draggingItemIndex != null) {
-      previousIndexOfDraggedItem = draggingItemIndex
-      val startOffset = draggingItemOffset
-      scope.launch {
-        previousItemOffset.snapTo(startOffset)
-        previousItemOffset.animateTo(
-          0f,
-          spring(stiffness = Spring.StiffnessMediumLow, visibilityThreshold = 1f)
-        )
-        previousIndexOfDraggedItem = null
-      }
-      // Notify that drag has ended - this triggers server sync
-      onDragEnd()
-    }
+    val hadDrag = draggingItemIndex != null
     draggingItemDraggedDelta = 0f
-    draggingItemIndex = null
     draggingItemInitialOffset = 0
+    if (hadDrag) {
+      // Keep draggingItemIndex / dragSourceIndex populated so the permutation
+      // continues to render the dropped item at its target slot until paging
+      // emits the new ordering after onDragEnd's dao.move.
+      isSettling = true
+      val version = ++settleVersion
+      onDragEnd()
+      scope.launch {
+        delay(SETTLE_TIMEOUT_MS)
+        if (version == settleVersion) {
+          isSettling = false
+          draggingItemIndex = null
+          dragSourceIndex = null
+        }
+      }
+    } else {
+      draggingItemIndex = null
+      dragSourceIndex = null
+    }
+  }
+
+  private companion object {
+    const val SETTLE_TIMEOUT_MS = 100L
   }
 
   internal fun onDrag(offset: Offset) {
@@ -155,8 +185,8 @@ fun rememberDragDropState(
   val state = remember(lazyListState) {
     DragDropState(
       state = lazyListState,
-      onMove = onMove,
       scope = scope,
+      onMove = onMove,
       onDragEnd = onDragEnd
     )
   }
@@ -169,6 +199,29 @@ fun rememberDragDropState(
   }
 
   return state
+}
+
+/**
+ * Maps a LazyColumn slot to the source-list index it should display, given
+ * the in-flight drag's [source] (where the drag started) and [target] (where
+ * the dragged item currently sits).
+ *
+ * This lets the LazyColumn render the visual reorder during a drag without
+ * mutating the underlying data — the dragged item appears at [target], items
+ * between [source] and [target] shift one slot toward [source], everything
+ * else stays put. On drag-end, the permutation collapses (source/target are
+ * cleared) and the next data emission carries the persisted order.
+ *
+ * Returns [slot] unchanged when no drag is in progress.
+ */
+fun displayedSourceIndex(slot: Int, source: Int?, target: Int?): Int {
+  if (source == null || target == null || source == target) return slot
+  return when {
+    slot == target -> source
+    source < target && slot in source until target -> slot + 1
+    source > target && slot in target + 1..source -> slot - 1
+    else -> slot
+  }
 }
 
 /**

--- a/core/ui/src/test/kotlin/com/kelsos/mbrc/core/ui/compose/DragDropStateSettleTest.kt
+++ b/core/ui/src/test/kotlin/com/kelsos/mbrc/core/ui/compose/DragDropStateSettleTest.kt
@@ -1,0 +1,135 @@
+package com.kelsos.mbrc.core.ui.compose
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CoroutineScope
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class DragDropStateSettleTest {
+
+  @get:Rule
+  val composeTestRule = createComposeRule()
+
+  @Test
+  fun `settle window opens after drag release and clears after the timeout`() {
+    val dragDrop = mountAndStartDrag(itemY = 50)
+
+    assertThat(dragDrop.dragSourceIndex).isNotNull()
+    assertThat(dragDrop.draggingItemIndex).isNotNull()
+    assertThat(dragDrop.isSettling).isFalse()
+
+    composeTestRule.runOnUiThread { dragDrop.onDragInterrupted() }
+    composeTestRule.waitForIdle()
+
+    assertThat(dragDrop.isSettling).isTrue()
+    assertThat(dragDrop.dragSourceIndex).isNotNull()
+
+    // Past the 100ms settle timeout the state must clear itself.
+    composeTestRule.mainClock.advanceTimeBy(SETTLE_TIMEOUT_MS * 4)
+    composeTestRule.waitForIdle()
+
+    assertThat(dragDrop.isSettling).isFalse()
+    assertThat(dragDrop.dragSourceIndex).isNull()
+    assertThat(dragDrop.draggingItemIndex).isNull()
+  }
+
+  @Test
+  fun `starting a new drag while a previous settle is pending invalidates the stale settle`() {
+    val dragDrop = mountAndStartDrag(itemY = 50)
+
+    composeTestRule.runOnUiThread { dragDrop.onDragInterrupted() }
+    composeTestRule.waitForIdle()
+    assertThat(dragDrop.isSettling).isTrue()
+
+    // Begin a second drag before the first settle's coroutine completes.
+    composeTestRule.runOnUiThread { dragDrop.onDragStart(Offset(0f, 50f)) }
+    composeTestRule.waitForIdle()
+
+    assertThat(dragDrop.isSettling).isFalse()
+    assertThat(dragDrop.dragSourceIndex).isNotNull()
+
+    // Let the original settle timeout fire. Because settleVersion bumped at
+    // the second onDragStart, the stale completion must NOT clear our state.
+    composeTestRule.mainClock.advanceTimeBy(SETTLE_TIMEOUT_MS * 4)
+    composeTestRule.waitForIdle()
+
+    assertThat(dragDrop.dragSourceIndex).isNotNull()
+    assertThat(dragDrop.draggingItemIndex).isNotNull()
+    assertThat(dragDrop.isSettling).isFalse()
+  }
+
+  @Test
+  fun `onDragInterrupted without a prior onDragStart is a no-op`() {
+    val dragDrop = mountWithoutDrag()
+
+    composeTestRule.runOnUiThread { dragDrop.onDragInterrupted() }
+    composeTestRule.waitForIdle()
+
+    assertThat(dragDrop.isSettling).isFalse()
+    assertThat(dragDrop.dragSourceIndex).isNull()
+    assertThat(dragDrop.draggingItemIndex).isNull()
+  }
+
+  private fun mountWithoutDrag(): DragDropState {
+    lateinit var listState: LazyListState
+    lateinit var scope: CoroutineScope
+    composeTestRule.setContent {
+      listState = rememberLazyListState()
+      scope = rememberCoroutineScope()
+      DragDropTestHost(listState = listState)
+    }
+    composeTestRule.waitForIdle()
+    return DragDropState(
+      state = listState,
+      scope = scope,
+      onMove = { _, _ -> },
+      onDragEnd = {}
+    )
+  }
+
+  private fun mountAndStartDrag(itemY: Int): DragDropState {
+    val dragDrop = mountWithoutDrag()
+    composeTestRule.runOnUiThread {
+      dragDrop.onDragStart(Offset(0f, itemY.toFloat()))
+    }
+    composeTestRule.waitForIdle()
+    return dragDrop
+  }
+
+  private companion object {
+    const val SETTLE_TIMEOUT_MS = 100L
+  }
+}
+
+@Composable
+private fun DragDropTestHost(listState: LazyListState) {
+  LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
+    items(count = 20, key = { it }) { index ->
+      Text(
+        text = "Item $index",
+        modifier = Modifier
+          .fillMaxWidth()
+          .height(40.dp)
+      )
+    }
+  }
+}

--- a/feature/playback/build.gradle.kts
+++ b/feature/playback/build.gradle.kts
@@ -17,6 +17,12 @@ android {
     compose = true
   }
 
+  testOptions {
+    unitTests {
+      isIncludeAndroidResources = true
+    }
+  }
+
   compileOptions {
     isCoreLibraryDesugaringEnabled = true
     sourceCompatibility = JavaVersion.VERSION_11
@@ -71,4 +77,6 @@ dependencies {
   testImplementation(libs.kotlin.coroutines.test)
   testImplementation(libs.mockk)
   testImplementation(libs.robolectric)
+  testImplementation(libs.androidx.compose.ui.test.junit4)
+  debugImplementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingRepository.kt
+++ b/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingRepository.kt
@@ -42,9 +42,10 @@ class NowPlayingRepositoryImpl(
 ) : NowPlayingRepository {
   override suspend fun count(): Long = withContext(dispatchers.database) { dao.count() }
 
-  override fun getAll(): Flow<PagingData<NowPlaying>> = paged({ dao.getAll() }) {
-    it.toNowPlaying()
-  }
+  override fun getAll(): Flow<PagingData<NowPlaying>> = paged(
+    pagingSourceFactory = { dao.getAll() },
+    enablePlaceholders = true
+  ) { it.toNowPlaying() }
 
   override suspend fun getRemote(progress: Progress?) {
     withContext(dispatchers.network) {

--- a/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingViewModel.kt
+++ b/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingViewModel.kt
@@ -8,6 +8,7 @@ import com.kelsos.mbrc.core.common.state.AppStateFlow
 import com.kelsos.mbrc.core.common.state.ConnectionStateFlow
 import com.kelsos.mbrc.core.common.utilities.coroutines.AppCoroutineDispatchers
 import com.kelsos.mbrc.core.data.nowplaying.NowPlaying
+import com.kelsos.mbrc.core.networking.protocol.SelfMutationTracker
 import com.kelsos.mbrc.core.networking.protocol.payloads.NowPlayingMoveRequest
 import com.kelsos.mbrc.core.networking.protocol.usecases.UserActionUseCase
 import com.kelsos.mbrc.core.networking.protocol.usecases.moveTrack
@@ -46,6 +47,7 @@ class NowPlayingActions(
   private val moveManager: MoveManager,
   private val userActionUseCase: UserActionUseCase,
   private val connectionStateFlow: ConnectionStateFlow,
+  private val selfMutationTracker: SelfMutationTracker,
   private val emit: suspend (uiMessage: NowPlayingUiMessages) -> Unit
 ) : INowPlayingActions {
   override fun reload() {
@@ -96,6 +98,7 @@ class NowPlayingActions(
       }
       try {
         delay(REMOVE_DELAY_MS)
+        selfMutationTracker.mark()
         userActionUseCase.removeTrack(position)
       } catch (e: IOException) {
         Timber.e(e)
@@ -153,7 +156,8 @@ class NowPlayingViewModel(
   moveManager: MoveManager,
   userActionUseCase: UserActionUseCase,
   connectionStateFlow: ConnectionStateFlow,
-  appState: AppStateFlow
+  appState: AppStateFlow,
+  selfMutationTracker: SelfMutationTracker
 ) : BaseViewModel<NowPlayingUiMessages>() {
   val tracks: Flow<PagingData<NowPlaying>> = repository.getAll().cachedIn(viewModelScope)
   val playingTrack = appState.playingTrack
@@ -168,6 +172,7 @@ class NowPlayingViewModel(
       moveManager = moveManager,
       userActionUseCase = userActionUseCase,
       connectionStateFlow = connectionStateFlow,
+      selfMutationTracker = selfMutationTracker,
       emit = this::emit
     )
 
@@ -176,6 +181,7 @@ class NowPlayingViewModel(
     moveManager.onMoveCommit { originalPosition, finalPosition ->
       viewModelScope.launch(dispatchers.network) {
         try {
+          selfMutationTracker.mark()
           userActionUseCase.moveTrack(NowPlayingMoveRequest(originalPosition, finalPosition))
           repository.move(originalPosition + 1, finalPosition + 1)
         } catch (e: IOException) {

--- a/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/compose/NowPlayingScreen.kt
+++ b/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/compose/NowPlayingScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.ScrollableDefaults
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
@@ -13,15 +15,17 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.QueueMusic
 import androidx.compose.material.icons.filled.Album
@@ -53,8 +57,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshots.SnapshotStateList
-import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -79,6 +81,7 @@ import com.kelsos.mbrc.core.ui.compose.DynamicScreenScaffold
 import com.kelsos.mbrc.core.ui.compose.EmptyScreen
 import com.kelsos.mbrc.core.ui.compose.LoadingScreen
 import com.kelsos.mbrc.core.ui.compose.TopBarState
+import com.kelsos.mbrc.core.ui.compose.displayedSourceIndex
 import com.kelsos.mbrc.core.ui.compose.dragContainer
 import com.kelsos.mbrc.core.ui.compose.rememberDragDropState
 import com.kelsos.mbrc.feature.minicontrol.MiniControl
@@ -248,7 +251,7 @@ private fun NowPlayingEventsEffect(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun NowPlayingContent(
+internal fun NowPlayingContent(
   tracks: LazyPagingItems<NowPlaying>,
   playingTrackPath: String,
   trackCount: Int,
@@ -261,35 +264,14 @@ private fun NowPlayingContent(
   onDragEnd: () -> Unit,
   onGoToAlbum: ((path: String) -> Unit)?,
   onGoToArtist: (artist: String) -> Unit,
-  modifier: Modifier = Modifier
+  modifier: Modifier = Modifier,
+  lazyListState: LazyListState = rememberLazyListState()
 ) {
-  // Hoist LazyListState here so it survives across refresh cycles
-  val lazyListState = rememberLazyListState()
-
-  // Use a snapshot state list for Compose to observe changes during drag
-  val draggableList = remember { mutableListOf<NowPlaying>().toMutableStateList() }
-
-  // Compute a signature of the paging data to detect actual changes
-  val dataSignature = remember(tracks.itemSnapshotList) {
-    tracks.itemSnapshotList.items.map { it.id }.hashCode()
-  }
-
-  // Sync list when data actually changes
-  LaunchedEffect(dataSignature) {
-    if (tracks.itemCount > 0) {
-      val newItems = tracks.itemSnapshotList.items
-      if (newItems.isNotEmpty()) {
-        // Check if content actually differs
-        val needsUpdate = draggableList.size != newItems.size ||
-          draggableList.zip(newItems).any { (old, new) -> old.id != new.id }
-
-        if (needsUpdate) {
-          draggableList.clear()
-          draggableList.addAll(newItems)
-        }
-      }
-    }
-  }
+  val dragDropState = rememberDragDropState(
+    lazyListState = lazyListState,
+    onMove = { from, to -> onTrackMove(from, to) },
+    onDragEnd = onDragEnd
+  )
 
   PullToRefreshBox(
     isRefreshing = isRefreshing,
@@ -297,22 +279,26 @@ private fun NowPlayingContent(
     modifier = modifier.fillMaxSize()
   ) {
     when (val refreshState = tracks.loadState.refresh) {
-      is LoadState.Loading if tracks.itemCount == 0 && draggableList.isEmpty() -> {
-        LoadingScreen()
+      is LoadState.Loading if tracks.itemCount == 0 -> {
+        ScrollablePlaceholder { LoadingScreen() }
       }
 
-      is LoadState.Error if tracks.itemCount == 0 && draggableList.isEmpty() -> {
-        EmptyScreen(
-          message = refreshState.error.message ?: stringResource(R.string.refresh_failed),
-          icon = Icons.AutoMirrored.Filled.QueueMusic
-        )
+      is LoadState.Error if tracks.itemCount == 0 -> {
+        ScrollablePlaceholder {
+          EmptyScreen(
+            message = refreshState.error.message ?: stringResource(R.string.refresh_failed),
+            icon = Icons.AutoMirrored.Filled.QueueMusic
+          )
+        }
       }
 
-      is LoadState.NotLoading if tracks.itemCount == 0 && draggableList.isEmpty() -> {
-        EmptyScreen(
-          message = stringResource(R.string.now_playing__empty_list),
-          icon = Icons.AutoMirrored.Filled.QueueMusic
-        )
+      is LoadState.NotLoading if tracks.itemCount == 0 -> {
+        ScrollablePlaceholder {
+          EmptyScreen(
+            message = stringResource(R.string.now_playing__empty_list),
+            icon = Icons.AutoMirrored.Filled.QueueMusic
+          )
+        }
       }
 
       else -> {
@@ -322,14 +308,12 @@ private fun NowPlayingContent(
           }
           NowPlayingTrackList(
             lazyListState = lazyListState,
-            draggableList = draggableList,
+            dragDropState = dragDropState,
             tracks = tracks,
             playingTrackPath = playingTrackPath,
             isConnected = isConnected,
             onTrackClick = onTrackClick,
             onTrackRemove = onTrackRemove,
-            onTrackMove = onTrackMove,
-            onDragEnd = onDragEnd,
             onGoToAlbum = onGoToAlbum,
             onGoToArtist = onGoToArtist,
             modifier = Modifier.weight(1f)
@@ -337,6 +321,20 @@ private fun NowPlayingContent(
         }
       }
     }
+  }
+}
+
+@Composable
+private fun ScrollablePlaceholder(content: @Composable BoxScope.() -> Unit) {
+  BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+    Box(
+      modifier = Modifier
+        .fillMaxWidth()
+        .heightIn(min = maxHeight)
+        .verticalScroll(rememberScrollState()),
+      contentAlignment = Alignment.Center,
+      content = content
+    )
   }
 }
 
@@ -357,34 +355,31 @@ private fun QueueHeader(trackCount: Int) {
 @Composable
 private fun NowPlayingTrackList(
   lazyListState: LazyListState,
-  draggableList: SnapshotStateList<NowPlaying>,
+  dragDropState: DragDropState,
   tracks: LazyPagingItems<NowPlaying>,
   playingTrackPath: String,
   isConnected: Boolean,
   onTrackClick: (Int) -> Unit,
   onTrackRemove: (Int) -> Unit,
-  onTrackMove: (Int, Int) -> Unit,
-  onDragEnd: () -> Unit,
   onGoToAlbum: ((path: String) -> Unit)?,
   onGoToArtist: (artist: String) -> Unit,
   modifier: Modifier = Modifier
 ) {
-  val dragDropState = rememberDragDropState(
-    lazyListState = lazyListState,
-    onMove = { from, to ->
-      draggableList.add(to, draggableList.removeAt(from))
-      onTrackMove(from, to)
-    },
-    onDragEnd = onDragEnd
-  )
-
-  // Only enable drag if connected
-  val dragModifier = if (isConnected) {
-    Modifier.dragContainer(dragDropState)
-  } else {
-    Modifier
+  val dragModifier = remember(isConnected, dragDropState) {
+    if (isConnected) Modifier.dragContainer(dragDropState) else Modifier
   }
 
+  // Captured once when the drag starts so we can detect — by id match at
+  // `target` — when paging has emitted the reordered window, and stop
+  // permuting before the dragged item snaps back.
+  val draggedId = remember(dragDropState.dragSourceIndex) {
+    dragDropState.dragSourceIndex?.let { tracks.peek(it)?.id }
+  }
+
+  // Iterates `tracks` directly so Paging anchors its next refresh around the
+  // user's actual scroll position. `enablePlaceholders=true` on the pager
+  // keeps `itemCount` stable across `dao.move()` invalidations, preventing
+  // the snap-to-page-boundary that broke consecutive drags past ~position 100.
   LazyColumn(
     state = lazyListState,
     modifier = modifier
@@ -392,22 +387,37 @@ private fun NowPlayingTrackList(
       .then(dragModifier),
     flingBehavior = ScrollableDefaults.flingBehavior()
   ) {
-    itemsIndexed(
-      items = draggableList,
-      key = { _, track -> track.id }
-    ) { index, track ->
-      val isDragging = index == dragDropState.draggingItemIndex
-      val isPlaying = track.path == playingTrackPath
+    items(
+      count = tracks.itemCount,
+      key = { slot ->
+        val srcIdx = sourceIndexFor(slot, dragDropState, tracks, draggedId)
+        tracks.peek(srcIdx)?.id ?: "${ContentTypes.PLACEHOLDER}-$srcIdx"
+      },
+      contentType = { slot ->
+        val srcIdx = sourceIndexFor(slot, dragDropState, tracks, draggedId)
+        when {
+          tracks.peek(srcIdx) == null -> ContentTypes.PLACEHOLDER
+          isConnected -> ContentTypes.TRACK_SWIPEABLE
+          else -> ContentTypes.TRACK_PLAIN
+        }
+      }
+    ) { slot ->
+      val srcIdx = sourceIndexFor(slot, dragDropState, tracks, draggedId)
+      val track = tracks[srcIdx]
+      val isDragging = slot == dragDropState.draggingItemIndex
+      val isPlaying = track?.path == playingTrackPath
 
-      if (isConnected) {
+      if (track == null) {
+        NowPlayingPlaceholderItem()
+      } else if (isConnected) {
         SwipeableNowPlayingItem(
           track = track,
-          index = index,
+          index = srcIdx,
           isPlaying = isPlaying,
           isDragging = isDragging,
           dragDropState = dragDropState,
-          onClick = { onTrackClick(index + 1) },
-          onRemove = { onTrackRemove(index) },
+          onClick = { onTrackClick(srcIdx + 1) },
+          onRemove = { onTrackRemove(srcIdx) },
           onGoToAlbum = onGoToAlbum?.let { callback -> { callback(track.path) } },
           onGoToArtist = { onGoToArtist(track.artist) }
         )
@@ -416,7 +426,7 @@ private fun NowPlayingTrackList(
           track = track,
           isPlaying = isPlaying,
           isDragging = false,
-          onClick = { onTrackClick(index + 1) },
+          onClick = { onTrackClick(srcIdx + 1) },
           onGoToAlbum = onGoToAlbum?.let { callback -> { callback(track.path) } },
           onGoToArtist = { onGoToArtist(track.artist) },
           modifier = Modifier.animateItem()
@@ -425,7 +435,7 @@ private fun NowPlayingTrackList(
     }
 
     if (tracks.loadState.append is LoadState.Loading) {
-      item(contentType = "loading") {
+      item(contentType = ContentTypes.LOADING) {
         Box(
           modifier = Modifier
             .fillMaxWidth()
@@ -437,6 +447,61 @@ private fun NowPlayingTrackList(
       }
     }
   }
+}
+
+private object ContentTypes {
+  const val PLACEHOLDER = "placeholder"
+  const val TRACK_SWIPEABLE = "track-swipeable"
+  const val TRACK_PLAIN = "track-plain"
+  const val LOADING = "loading"
+}
+
+private fun sourceIndexFor(
+  slot: Int,
+  dragDropState: DragDropState,
+  tracks: LazyPagingItems<NowPlaying>,
+  draggedId: Long?
+): Int = resolveSourceIndex(
+  slot = slot,
+  source = dragDropState.dragSourceIndex,
+  target = dragDropState.draggingItemIndex,
+  isSettling = dragDropState.isSettling,
+  draggedId = draggedId,
+  idAtTarget = { tgt -> tracks.peek(tgt)?.id }
+)
+
+/**
+ * Computes the source-list index a LazyColumn slot should render. Applies
+ * the in-flight drag permutation, except once paging has emitted the
+ * reordered data after a drop — detected by [idAtTarget] returning the id
+ * captured at drag-start. From that point until [DragDropState] clears its
+ * drag indices, slots map directly (no permutation), so neighbor keys stay
+ * stable and `animateItem` doesn't fire spurious placement animations.
+ */
+internal fun resolveSourceIndex(
+  slot: Int,
+  source: Int?,
+  target: Int?,
+  isSettling: Boolean,
+  draggedId: Long?,
+  idAtTarget: (Int) -> Long?
+): Int {
+  if (source == null || target == null) return slot
+  val pagingHasNewOrder = isSettling &&
+    draggedId != null &&
+    idAtTarget(target) == draggedId
+  if (pagingHasNewOrder) return slot
+  return displayedSourceIndex(slot = slot, source = source, target = target)
+}
+
+@Composable
+private fun NowPlayingPlaceholderItem() {
+  Box(
+    modifier = Modifier
+      .fillMaxWidth()
+      .height(64.dp)
+      .background(MaterialTheme.colorScheme.surface)
+  )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -458,22 +523,12 @@ private fun LazyItemScope.SwipeableNowPlayingItem(
   )
 
   // Apply drag visual effects
-  val draggingModifier = when {
-    isDragging -> {
-      Modifier
-        .zIndex(1f)
-        .graphicsLayer { translationY = dragDropState.draggingItemOffset }
-    }
-
-    index == dragDropState.previousIndexOfDraggedItem -> {
-      Modifier
-        .zIndex(1f)
-        .graphicsLayer { translationY = dragDropState.previousItemOffset.value }
-    }
-
-    else -> {
-      Modifier.animateItem(fadeInSpec = null, fadeOutSpec = null)
-    }
+  val draggingModifier = if (isDragging) {
+    Modifier
+      .zIndex(1f)
+      .graphicsLayer { translationY = dragDropState.draggingItemOffset }
+  } else {
+    Modifier.animateItem(fadeInSpec = null, fadeOutSpec = null)
   }
 
   SwipeToDismissBox(

--- a/feature/playback/src/test/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingViewModelTest.kt
+++ b/feature/playback/src/test/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingViewModelTest.kt
@@ -12,6 +12,8 @@ import com.kelsos.mbrc.core.common.test.testDispatcher
 import com.kelsos.mbrc.core.common.test.testDispatcherModule
 import com.kelsos.mbrc.core.data.nowplaying.NowPlaying
 import com.kelsos.mbrc.core.data.nowplaying.SearchResult
+import com.kelsos.mbrc.core.networking.protocol.SelfMutationConfig
+import com.kelsos.mbrc.core.networking.protocol.SelfMutationTracker
 import com.kelsos.mbrc.core.networking.protocol.actions.UserAction
 import com.kelsos.mbrc.core.networking.protocol.base.Protocol
 import com.kelsos.mbrc.core.networking.protocol.usecases.UserActionUseCase
@@ -43,6 +45,7 @@ class NowPlayingViewModelTest : KoinTest {
       single<UserActionUseCase> { mockk(relaxed = true) }
       single<ConnectionStateFlow> { mockk(relaxed = true) }
       single<AppStateFlow> { mockk(relaxed = true) }
+      single { SelfMutationTracker(clock = { 0L }, config = SelfMutationConfig()) }
       singleOf(::NowPlayingViewModel)
     }
 
@@ -556,6 +559,52 @@ class NowPlayingViewModelTest : KoinTest {
 
       // Verify moveManager.commit was called
       coVerify(exactly = 1) { moveManager.commit() }
+    }
+  }
+
+  @Test
+  fun multipleMoveTrackCallsBatchIntoASingleNetworkMessageOnCommit() {
+    runTest(testDispatcher) {
+      // Given — a real MoveManagerImpl batches every per-row swap during the drag
+      // and submits one (originalPosition, finalPosition) tuple on commit().
+      val realMoveManager = MoveManagerImpl()
+      val realModule = module {
+        single<NowPlayingRepository> { mockk(relaxed = true) }
+        single<MoveManager> { realMoveManager }
+        single<UserActionUseCase> { mockk(relaxed = true) }
+        single<ConnectionStateFlow> { mockk(relaxed = true) }
+        single<AppStateFlow> { mockk(relaxed = true) }
+        single { SelfMutationTracker(clock = { 0L }, config = SelfMutationConfig()) }
+        singleOf(::NowPlayingViewModel)
+      }
+
+      stopKoin()
+      startKoin { modules(listOf(realModule, testDispatcherModule)) }
+
+      val realRepository: NowPlayingRepository by inject()
+      val realUserAction: UserActionUseCase by inject()
+      val realConnectionState: ConnectionStateFlow by inject()
+      val realAppState: AppStateFlow by inject()
+      val realViewModel: NowPlayingViewModel by inject()
+
+      every { realRepository.getAll() } returns flowOf(PagingData.empty())
+      every { realAppState.playingTrack } returns MutableStateFlow<TrackInfo>(BasicTrackInfo())
+      coEvery { realConnectionState.isConnected } returns true
+      coEvery { realUserAction.perform(any()) } returns Unit
+      coEvery { realRepository.move(any(), any()) } returns Unit
+
+      // When — simulate a drag through several intermediate positions
+      realViewModel.actions.moveTrack(from = 10, to = 9)
+      realViewModel.actions.moveTrack(from = 9, to = 8)
+      realViewModel.actions.moveTrack(from = 8, to = 7)
+      realViewModel.actions.moveTrack(from = 7, to = 6)
+      realViewModel.actions.move()
+      testDispatcher.scheduler.advanceUntilIdle()
+
+      // Then — exactly one network call carrying (originalPosition=10, finalPosition=6).
+      coVerify(exactly = 1) { realUserAction.perform(any()) }
+      // And exactly one local DB swap.
+      coVerify(exactly = 1) { realRepository.move(11, 7) }
     }
   }
 }

--- a/feature/playback/src/test/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/compose/DisplayedSourceIndexTest.kt
+++ b/feature/playback/src/test/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/compose/DisplayedSourceIndexTest.kt
@@ -1,0 +1,94 @@
+package com.kelsos.mbrc.feature.playback.nowplaying.compose
+
+import com.google.common.truth.Truth.assertThat
+import com.kelsos.mbrc.core.ui.compose.displayedSourceIndex
+import org.junit.Test
+
+/**
+ * Verifies the in-flight drag permutation: given that the dragged item started
+ * at `source` and currently sits at `target`, what should each LazyColumn slot
+ * render? The function maps slot → source-list index without mutating any
+ * underlying data; the rest of the list shifts by one slot toward `source`.
+ */
+class DisplayedSourceIndexTest {
+
+  @Test
+  fun `no drag in progress passes the slot through unchanged`() {
+    for (slot in 0..10) {
+      assertThat(displayedSourceIndex(slot, source = null, target = null)).isEqualTo(slot)
+      assertThat(displayedSourceIndex(slot, source = 5, target = null)).isEqualTo(slot)
+      assertThat(displayedSourceIndex(slot, source = null, target = 5)).isEqualTo(slot)
+    }
+  }
+
+  @Test
+  fun `dragged-onto-itself passes the slot through unchanged`() {
+    for (slot in 0..10) {
+      assertThat(displayedSourceIndex(slot, source = 5, target = 5)).isEqualTo(slot)
+    }
+  }
+
+  @Test
+  fun `moving down shifts intermediate slots up by one and renders source at target`() {
+    // Source list: [A B C D E F]; user drags B (index 1) down onto E (index 4).
+    // Expected displayed order: [A C D E B F].
+    // Slot 0 -> A (0), slot 1 -> C (2), slot 2 -> D (3), slot 3 -> E (4),
+    // slot 4 -> B (1, the dragged item), slot 5 -> F (5).
+    val src = 1
+    val tgt = 4
+    assertThat(displayedSourceIndex(0, src, tgt)).isEqualTo(0)
+    assertThat(displayedSourceIndex(1, src, tgt)).isEqualTo(2)
+    assertThat(displayedSourceIndex(2, src, tgt)).isEqualTo(3)
+    assertThat(displayedSourceIndex(3, src, tgt)).isEqualTo(4)
+    assertThat(displayedSourceIndex(4, src, tgt)).isEqualTo(1)
+    assertThat(displayedSourceIndex(5, src, tgt)).isEqualTo(5)
+  }
+
+  @Test
+  fun `moving up shifts intermediate slots down by one and renders source at target`() {
+    // Source list: [A B C D E F]; user drags E (index 4) up onto B (index 1).
+    // Expected displayed order: [A E B C D F].
+    val src = 4
+    val tgt = 1
+    assertThat(displayedSourceIndex(0, src, tgt)).isEqualTo(0)
+    assertThat(displayedSourceIndex(1, src, tgt)).isEqualTo(4)
+    assertThat(displayedSourceIndex(2, src, tgt)).isEqualTo(1)
+    assertThat(displayedSourceIndex(3, src, tgt)).isEqualTo(2)
+    assertThat(displayedSourceIndex(4, src, tgt)).isEqualTo(3)
+    assertThat(displayedSourceIndex(5, src, tgt)).isEqualTo(5)
+  }
+
+  @Test
+  fun `single-step move is the trivial swap`() {
+    // Down by one: drag from 2 to 3.
+    assertThat(displayedSourceIndex(2, source = 2, target = 3)).isEqualTo(3)
+    assertThat(displayedSourceIndex(3, source = 2, target = 3)).isEqualTo(2)
+
+    // Up by one: drag from 3 to 2.
+    assertThat(displayedSourceIndex(2, source = 3, target = 2)).isEqualTo(3)
+    assertThat(displayedSourceIndex(3, source = 3, target = 2)).isEqualTo(2)
+  }
+
+  @Test
+  fun `slots well outside the drag range are untouched`() {
+    val src = 100
+    val tgt = 110
+    for (slot in listOf(0, 50, 99, 111, 200, 1000)) {
+      assertThat(displayedSourceIndex(slot, src, tgt)).isEqualTo(slot)
+    }
+  }
+
+  @Test
+  fun `permutation is a bijection over the affected range`() {
+    // Move down from 2 to 7: every slot in [0, 10) must map to a unique
+    // source index in [0, 10) — no item shown twice, no item dropped.
+    val src = 2
+    val tgt = 7
+    val mapped = (0 until 10).map { displayedSourceIndex(it, src, tgt) }
+    assertThat(mapped.toSet()).isEqualTo((0 until 10).toSet())
+
+    // Same property when moving up.
+    val mappedUp = (0 until 10).map { displayedSourceIndex(it, source = 7, target = 2) }
+    assertThat(mappedUp.toSet()).isEqualTo((0 until 10).toSet())
+  }
+}

--- a/feature/playback/src/test/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/compose/NowPlayingScreenTest.kt
+++ b/feature/playback/src/test/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/compose/NowPlayingScreenTest.kt
@@ -1,0 +1,195 @@
+package com.kelsos.mbrc.feature.playback.nowplaying.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeUp
+import androidx.paging.LoadState
+import androidx.paging.LoadStates
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.kelsos.mbrc.core.data.nowplaying.NowPlaying
+import kotlinx.coroutines.flow.flowOf
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class NowPlayingScreenTest {
+
+  @get:Rule
+  val composeTestRule = createComposeRule()
+
+  @Test
+  fun `empty state shows the empty message`() {
+    composeTestRule.setEmptyContent()
+
+    composeTestRule.onNodeWithText("Your queue is empty").assertIsDisplayed()
+  }
+
+  @Test
+  fun `empty state is wrapped in a scrollable container so pull-to-refresh works`() {
+    composeTestRule.setEmptyContent()
+
+    // PullToRefreshBox requires its child to be vertically scrollable to detect
+    // the pull gesture; without it the empty state never triggers refresh.
+    composeTestRule.onNode(hasScrollAction()).assertExists()
+  }
+
+  @Test
+  fun `with placeholders enabled total item count equals dataset size before any load`() {
+    // Regression for the snap-to-page-boundary bug. Without placeholders, the
+    // LazyPagingItems item count was the number of loaded items (~100 after
+    // initial load). After a dao.move invalidation the count would briefly
+    // shrink to the new initial-load size, the LazyColumn would clamp the
+    // scroll anchor to that smaller list, and the user would land on
+    // position ~100 regardless of where they had been.
+    //
+    // With placeholders enabled, item count = total dataset size from the
+    // moment the first page lands, so the LazyColumn never sees the list
+    // shrink.
+    val totalItems = 350
+    val source = CountingPagingSource(totalItems = totalItems)
+    val pager = Pager(
+      config = PagingConfig(
+        pageSize = 50,
+        initialLoadSize = 100,
+        prefetchDistance = 25,
+        enablePlaceholders = true
+      ),
+      pagingSourceFactory = { source }
+    )
+
+    var observedItemCount = 0
+    composeTestRule.setContent {
+      val tracks = pager.flow.collectAsLazyPagingItems()
+      observedItemCount = tracks.itemCount
+      TestNowPlayingContent(
+        tracks = tracks,
+        trackCount = totalItems,
+        isConnected = false
+      )
+    }
+
+    composeTestRule.waitUntil(timeoutMillis = 5_000) {
+      observedItemCount == totalItems
+    }
+    assertThat(observedItemCount).isEqualTo(totalItems)
+  }
+
+  @Test
+  fun `scrolling past the initial page triggers paging beyond the initial load size`() {
+    val totalItems = 400
+    val source = CountingPagingSource(totalItems = totalItems)
+    val pager = Pager(
+      config = PagingConfig(
+        pageSize = 50,
+        initialLoadSize = 100,
+        prefetchDistance = 25,
+        enablePlaceholders = false
+      ),
+      pagingSourceFactory = { source }
+    )
+
+    composeTestRule.setContent {
+      TestNowPlayingContent(
+        tracks = pager.flow.collectAsLazyPagingItems(),
+        trackCount = totalItems,
+        isConnected = false
+      )
+    }
+
+    composeTestRule.waitUntil(timeoutMillis = 5_000) { source.loadCount >= 1 }
+    val initialLoads = source.loadCount
+
+    for (i in 0 until 20) {
+      if (source.loadCount > initialLoads) break
+      composeTestRule.onRoot().performTouchInput { swipeUp() }
+      composeTestRule.waitForIdle()
+    }
+
+    assertThat(source.loadCount).isGreaterThan(initialLoads)
+  }
+}
+
+private class CountingPagingSource(private val totalItems: Int) : PagingSource<Int, NowPlaying>() {
+  @Volatile var loadCount: Int = 0
+    private set
+
+  override fun getRefreshKey(state: PagingState<Int, NowPlaying>): Int? = null
+
+  override suspend fun load(params: LoadParams<Int>): LoadResult<Int, NowPlaying> {
+    loadCount += 1
+    val key = params.key ?: 0
+    val end = (key + params.loadSize).coerceAtMost(totalItems)
+    val data = (key until end).map { i ->
+      NowPlaying(
+        id = i.toLong() + 1,
+        title = "Track ${i + 1}",
+        artist = "Artist ${i + 1}",
+        path = "/path/$i",
+        position = i + 1
+      )
+    }
+    val nextKey = if (end >= totalItems) null else end
+    val prevKey = if (key == 0) null else (key - params.loadSize).coerceAtLeast(0)
+    return LoadResult.Page(
+      data = data,
+      prevKey = prevKey,
+      nextKey = nextKey,
+      itemsBefore = key,
+      itemsAfter = totalItems - end
+    )
+  }
+}
+
+private fun ComposeContentTestRule.setEmptyContent() {
+  setContent {
+    val tracks = flowOf(
+      PagingData.empty<NowPlaying>(
+        sourceLoadStates = LoadStates(
+          refresh = LoadState.NotLoading(endOfPaginationReached = true),
+          prepend = LoadState.NotLoading(endOfPaginationReached = true),
+          append = LoadState.NotLoading(endOfPaginationReached = true)
+        )
+      )
+    ).collectAsLazyPagingItems()
+    TestNowPlayingContent(tracks = tracks, trackCount = 0, isConnected = true)
+  }
+}
+
+@Composable
+private fun TestNowPlayingContent(
+  tracks: LazyPagingItems<NowPlaying>,
+  trackCount: Int,
+  isConnected: Boolean
+) {
+  NowPlayingContent(
+    tracks = tracks,
+    playingTrackPath = "",
+    trackCount = trackCount,
+    isRefreshing = false,
+    isConnected = isConnected,
+    onRefresh = {},
+    onTrackClick = {},
+    onTrackRemove = {},
+    onTrackMove = { _, _ -> },
+    onDragEnd = {},
+    onGoToAlbum = null,
+    onGoToArtist = {}
+  )
+}

--- a/feature/playback/src/test/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/compose/ResolveSourceIndexTest.kt
+++ b/feature/playback/src/test/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/compose/ResolveSourceIndexTest.kt
@@ -1,0 +1,131 @@
+package com.kelsos.mbrc.feature.playback.nowplaying.compose
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ResolveSourceIndexTest {
+
+  private val noIdAtTarget: (Int) -> Long? = { null }
+
+  @Test
+  fun `no drag - source null - returns slot unchanged`() {
+    val result = resolveSourceIndex(
+      slot = 3,
+      source = null,
+      target = 5,
+      isSettling = false,
+      draggedId = 99L,
+      idAtTarget = noIdAtTarget
+    )
+    assertThat(result).isEqualTo(3)
+  }
+
+  @Test
+  fun `no drag - target null - returns slot unchanged`() {
+    val result = resolveSourceIndex(
+      slot = 3,
+      source = 5,
+      target = null,
+      isSettling = true,
+      draggedId = 99L,
+      idAtTarget = { 99L }
+    )
+    assertThat(result).isEqualTo(3)
+  }
+
+  @Test
+  fun `active drag - applies permutation`() {
+    // Drag from 1 to 4: slot 4 should display the source item (index 1).
+    val result = resolveSourceIndex(
+      slot = 4,
+      source = 1,
+      target = 4,
+      isSettling = false,
+      draggedId = 42L,
+      idAtTarget = noIdAtTarget
+    )
+    assertThat(result).isEqualTo(1)
+  }
+
+  @Test
+  fun `settling but paging has not caught up - keeps applying permutation`() {
+    // Mid-settle: idAtTarget still returns a stale id (the neighbor that
+    // was originally at target). Permutation must hold to avoid snap-back.
+    val staleNeighborId = 7L
+    val draggedId = 42L
+    val result = resolveSourceIndex(
+      slot = 4,
+      source = 1,
+      target = 4,
+      isSettling = true,
+      draggedId = draggedId,
+      idAtTarget = { staleNeighborId }
+    )
+    assertThat(result).isEqualTo(1)
+  }
+
+  @Test
+  fun `settling and paging emitted reorder - passes slot through`() {
+    // Paging has caught up: idAtTarget now returns the dragged item's id,
+    // so the permutation is no longer needed. Slot maps straight through;
+    // the LazyColumn renders the persisted order directly.
+    val draggedId = 42L
+    val result = resolveSourceIndex(
+      slot = 4,
+      source = 1,
+      target = 4,
+      isSettling = true,
+      draggedId = draggedId,
+      idAtTarget = { draggedId }
+    )
+    assertThat(result).isEqualTo(4)
+  }
+
+  @Test
+  fun `settling with null draggedId - falls back to permutation`() {
+    // draggedId is null when the source slot was a placeholder at drag-start
+    // (peek returned null). We can't detect the paging emission without an
+    // id to compare against, so we hold the permutation until the SETTLE
+    // timeout clears the drag state.
+    val result = resolveSourceIndex(
+      slot = 4,
+      source = 1,
+      target = 4,
+      isSettling = true,
+      draggedId = null,
+      idAtTarget = { 42L }
+    )
+    assertThat(result).isEqualTo(1)
+  }
+
+  @Test
+  fun `idAtTarget is only consulted while settling`() {
+    var calls = 0
+    val countingIdAtTarget: (Int) -> Long? = {
+      calls += 1
+      42L
+    }
+    resolveSourceIndex(
+      slot = 4,
+      source = 1,
+      target = 4,
+      isSettling = false,
+      draggedId = 42L,
+      idAtTarget = countingIdAtTarget
+    )
+    assertThat(calls).isEqualTo(0)
+  }
+
+  @Test
+  fun `slots outside the drag range pass through during active drag`() {
+    val result = resolveSourceIndex(
+      slot = 50,
+      source = 1,
+      target = 4,
+      isSettling = false,
+      draggedId = 42L,
+      idAtTarget = noIdAtTarget
+    )
+    assertThat(result).isEqualTo(50)
+  }
+}


### PR DESCRIPTION
## Summary
Three related fixes for the now playing queue, split into one commit each so they can be reviewed independently.

- **Pull-to-refresh on empty queue** — `PullToRefreshBox` needs vertically-scrollable content to detect the gesture. The empty/loading/error branches rendered a static `Box`, so users on an empty queue couldn't pull to refresh. Each branch now renders inside a `ScrollablePlaceholder` that mirrors the `BoxWithConstraints + verticalScroll` idiom already used by `core/ui/Composables.kt`'s `SwipeRefreshScreen`.
- **100-item paging cap** — the LazyColumn iterates a snapshot copy (`draggableList`) to support drag & drop, so it never reads `tracks[i]` directly and Paging 3 had no signal to load past `initialLoadSize`. A `LaunchedEffect` now observes the last visible index via `snapshotFlow` and pings `tracks[i]`, restoring stock prefetch behaviour.
- **Drag across page boundaries** — once paging actually advances, a page that lands mid-drag was clobbering the local list and snapping the dragged item back. `dragDropState` is now hoisted into `NowPlayingContent`, and the new `reconcileDraggableList` helper preserves the local order during a drag and only appends ids that aren't yet present, so reorders across the page border keep the newly loaded items reachable as drop targets. The full reconcile resumes on the next emission after the drag ends.

## Test plan
- [x] `./gradlew verifyLocal` (format + lint + detekt + tests + screenshot validation) — passes
- [x] New tests in `feature:playback`:
  - `NowPlayingScreenTest`: empty state shows the empty message; empty state is wrapped in a scrollable container; scrolling past the initial page triggers paging beyond `initialLoadSize` (sanity-checked by reverting the fix and confirming the test fails)
  - `ReconcileDraggableListTest`: 6 cases covering the idle-replace, drag-preserve, append-on-page-load, and post-drag reconcile semantics (sanity-checked by reverting the fix and confirming 4 of 6 fail)
- [ ] Manual smoke test on a real queue >100 items: scroll to confirm full queue loads, pull-to-refresh on an empty queue, drag a track across a freshly-loaded page boundary

## Notes
- Adds compose UI test infra (`androidx.compose.ui.test.junit4` + `testOptions { unitTests { isIncludeAndroidResources = true } }`) to `feature/playback/build.gradle.kts` so the empty-state and paging behaviour can be verified via Robolectric.
- Bumps `NowPlayingContent` and `reconcileDraggableList` to `internal` to make them addressable from tests.