### PR TITLE
chore: fix detekt failures surfaced by type-resolution analysis

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,8 +117,11 @@ dependencies {
 }
 
 tasks.register("staticAnalysisAll") {
-  description = "Runs detekt, lint, and kotlinter on all modules"
-  dependsOn(subprojects.flatMap { it.tasks.matching { t -> t.name == "detekt" } })
+  description = "Runs detekt (with type resolution), lint, and kotlinter on all modules"
+  // detektDebug runs with type resolution, which is required for rules like
+  // RedundantSuspendModifier that inspect call sites. The bare `detekt` task
+  // skips type resolution and silently misses these.
+  dependsOn(subprojects.flatMap { it.tasks.matching { t -> t.name == "detektDebug" } })
   dependsOn(subprojects.flatMap { it.tasks.matching { t -> t.name == "lintKotlin" } })
   dependsOn(subprojects.flatMap { it.tasks.matching { t -> t.name == "lint" } })
 }
@@ -138,10 +141,17 @@ abstract class CollectSarifReportsTask : DefaultTask() {
 
     val buildDirs = subprojectBuildDirs.get()
 
-    // Collect and merge detekt SARIF reports
+    // Collect and merge detekt SARIF reports. staticAnalysisAll runs
+    // :detektDebug (with type resolution), which emits debug.sarif;
+    // fall back to detekt.sarif for any module that ran the bare task.
     val detektFiles = buildDirs.mapNotNull { buildDir ->
-      val sarifFile = File(buildDir, "reports/detekt/detekt.sarif")
-      if (sarifFile.exists()) sarifFile else null
+      val debugSarif = File(buildDir, "reports/detekt/debug.sarif")
+      val baseSarif = File(buildDir, "reports/detekt/detekt.sarif")
+      when {
+        debugSarif.exists() -> debugSarif
+        baseSarif.exists() -> baseSarif
+        else -> null
+      }
     }
     if (detektFiles.isNotEmpty()) {
       mergeSarifFiles(detektFiles, File(outputDir, "detekt.sarif"))

--- a/core/data/src/main/kotlin/com/kelsos/mbrc/core/data/migration/DefaultConnectionMigration.kt
+++ b/core/data/src/main/kotlin/com/kelsos/mbrc/core/data/migration/DefaultConnectionMigration.kt
@@ -14,7 +14,7 @@ class DefaultConnectionMigration(
   private val sharedPreferences: SharedPreferences,
   private val connectionDao: ConnectionDao
 ) {
-  suspend fun migrate(): Boolean {
+  fun migrate(): Boolean {
     if (!sharedPreferences.contains(OLD_DEFAULT_KEY)) {
       Timber.d("No default connection key found in SharedPreferences, nothing to migrate")
       return false

--- a/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/MessageHandler.kt
+++ b/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/MessageHandler.kt
@@ -139,7 +139,7 @@ class MessageHandlerImpl(
   }
 
   private suspend fun execute(event: MessageEvent) {
-    val action = get(event.type)
+    val action: ProtocolAction = get(event.type)
       .onFailure { Timber.e(it, "Failed to resolve command for $event") }
       .getOrNull() ?: return
     try {
@@ -151,7 +151,7 @@ class MessageHandlerImpl(
     }
   }
 
-  private fun get(context: Protocol) = runCatching {
+  private fun get(context: Protocol): Result<ProtocolAction> = runCatching {
     commands.computeIfAbsent(context) { protocol ->
       actionFactory.create(protocol)
     }

--- a/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/SocketActivityChecker.kt
+++ b/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/SocketActivityChecker.kt
@@ -66,10 +66,9 @@ class SocketActivityChecker(dispatchers: AppCoroutineDispatchers) {
   }
 
   private suspend fun cancel() {
-    deferred?.run {
-      if (isActive) {
-        cancelAndJoin()
-      }
+    val job = deferred ?: return
+    if (job.isActive) {
+      job.cancelAndJoin()
     }
   }
 

--- a/feature/library/src/main/kotlin/com/kelsos/mbrc/feature/library/BaseLibraryViewModel.kt
+++ b/feature/library/src/main/kotlin/com/kelsos/mbrc/feature/library/BaseLibraryViewModel.kt
@@ -26,5 +26,5 @@ open class BaseLibraryViewModel<T : UiMessageBase>(
     }
   }
 
-  protected suspend fun checkConnection(): Boolean = connectionStateFlow.isConnected
+  protected fun checkConnection(): Boolean = connectionStateFlow.isConnected
 }

--- a/feature/library/src/main/kotlin/com/kelsos/mbrc/feature/library/artists/GenreArtistsViewModel.kt
+++ b/feature/library/src/main/kotlin/com/kelsos/mbrc/feature/library/artists/GenreArtistsViewModel.kt
@@ -33,7 +33,7 @@ class GenreArtistsViewModel(
 
   override val artists: Flow<PagingData<Artist>> =
     combine(genre, librarySettings.artistSortPreferenceFlow) { id, sort ->
-      Pair(id, sort.order)
+      id to sort.order
     }.flatMapLatest { (id, order) ->
       repository.getArtistByGenre(id, order)
     }.cachedIn(viewModelScope)

--- a/feature/library/src/main/kotlin/com/kelsos/mbrc/feature/library/domain/LibrarySyncUseCase.kt
+++ b/feature/library/src/main/kotlin/com/kelsos/mbrc/feature/library/domain/LibrarySyncUseCase.kt
@@ -2,7 +2,6 @@ package com.kelsos.mbrc.feature.library.domain
 
 import com.kelsos.mbrc.core.common.utilities.AppError
 import com.kelsos.mbrc.core.common.utilities.Outcome
-import com.kelsos.mbrc.core.data.cacheIsEmpty
 import com.kelsos.mbrc.core.data.library.album.AlbumRepository
 import com.kelsos.mbrc.core.data.library.artist.ArtistRepository
 import com.kelsos.mbrc.core.data.library.genre.GenreRepository
@@ -105,10 +104,10 @@ class LibrarySyncUseCaseImpl(
 
   private suspend fun checkIfShouldSync(auto: Boolean): Boolean = !auto || isEmpty()
 
-  private suspend fun isEmpty(): Boolean = genreRepository.cacheIsEmpty() &&
-    artistRepository.cacheIsEmpty() &&
-    albumRepository.cacheIsEmpty() &&
-    trackRepository.cacheIsEmpty()
+  private suspend fun isEmpty(): Boolean = genreRepository.count() == 0L &&
+    artistRepository.count() == 0L &&
+    albumRepository.count() == 0L &&
+    trackRepository.count() == 0L
 
   override fun isRunning(): Boolean = running
 }


### PR DESCRIPTION
## Summary
- Switches `staticAnalysisAll` to depend on `:detektDebug` so detekt runs with type resolution enabled — rules like `RedundantSuspendModifier`, `UnusedImports`, and `PreferToOverPairSyntax` need call-site info and were silently passing on the bare `:detekt` task.
- Cleans up the violations the stricter analysis surfaces across networking, library, and data modules. No behavior changes.

## Changes
- `SocketActivityChecker.cancel`: rewrite `?.run { ... }` as an explicit null check so the `cancelAndJoin` suspend call is visible.
- `MessageHandler.execute`: annotate the resolved action with an explicit `ProtocolAction` type so detekt can see `action.execute` is a suspend call.
- `DefaultConnectionMigration.migrate`: drop redundant `suspend` modifier (caller wraps with `withContext`).
- `BaseLibraryViewModel.checkConnection`: drop redundant `suspend` modifier (`isConnected` is a `val`).
- `LibrarySyncUseCase.isEmpty`: replace the `cacheIsEmpty` extension chain with direct `count() == 0L` calls so type resolution sees the suspending hits.
- `GenreArtistsViewModel`: use `to` infix instead of `Pair(...)`.

## Test plan
- [x] `./gradlew formatKotlin` — clean
- [x] `./gradlew staticAnalysisAll` — passes with `:detektDebug`
- [x] `./gradlew test` — all unit tests green