### PR TITLE
fix(networking): tolerate empty-array Page payloads from the server

### DIFF
--- a/app/src/main/kotlin/com/kelsos/mbrc/AppModule.kt
+++ b/app/src/main/kotlin/com/kelsos/mbrc/AppModule.kt
@@ -37,6 +37,7 @@ import com.kelsos.mbrc.core.networking.protocol.actions.NowPlayingHandler
 import com.kelsos.mbrc.core.networking.protocol.actions.PlayerStateHandler
 import com.kelsos.mbrc.core.networking.protocol.actions.PluginVersionHandler
 import com.kelsos.mbrc.core.networking.protocol.actions.TrackChangeNotifier
+import com.kelsos.mbrc.core.networking.protocol.models.PageAdapterFactory
 import com.kelsos.mbrc.core.platform.service.ServiceRestarter
 import com.kelsos.mbrc.feature.content.contentModule
 import com.kelsos.mbrc.feature.library.libraryModule
@@ -114,7 +115,7 @@ val appModule = module {
   }
 
   // Serialization
-  single { Moshi.Builder().build() }
+  single { Moshi.Builder().add(PageAdapterFactory).build() }
 
   // Networking Module Adapters
   // These adapters implement interfaces defined in core/networking module

--- a/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/protocol/models/PageAdapterFactory.kt
+++ b/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/protocol/models/PageAdapterFactory.kt
@@ -1,0 +1,43 @@
+package com.kelsos.mbrc.core.networking.protocol.models
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import java.lang.reflect.Type
+
+/**
+ * Tolerates servers that emit `data: []` (or a bare top-level `[]`) for an
+ * empty page instead of the documented `{ total, offset, limit, data: [] }`
+ * object. Without this, the generated adapter throws `JsonDataException:
+ * Expected BEGIN_OBJECT but was BEGIN_ARRAY` and aborts pagination.
+ */
+object PageAdapterFactory : JsonAdapter.Factory {
+  override fun create(type: Type, annotations: Set<Annotation>, moshi: Moshi): JsonAdapter<*>? {
+    if (annotations.isNotEmpty()) return null
+    if (Types.getRawType(type) != Page::class.java) return null
+
+    val delegate = moshi.nextAdapter<Any>(this, type, annotations)
+    return EmptyArrayTolerantPageAdapter(delegate)
+  }
+
+  private class EmptyArrayTolerantPageAdapter(private val delegate: JsonAdapter<Any>) :
+    JsonAdapter<Any>() {
+    override fun fromJson(reader: JsonReader): Any? {
+      if (reader.peek() == JsonReader.Token.BEGIN_ARRAY) {
+        reader.skipValue()
+        // Synthesize a terminal empty page so ApiBase.getAllPages's
+        // `offset + limit > total` break condition fires immediately
+        // (1 > 0) instead of looping forever against a server that keeps
+        // returning bare arrays.
+        return Page<Any>().apply { limit = 1 }
+      }
+      return delegate.fromJson(reader)
+    }
+
+    override fun toJson(writer: JsonWriter, value: Any?) {
+      delegate.toJson(writer, value)
+    }
+  }
+}

--- a/core/networking/src/test/kotlin/com/kelsos/mbrc/core/networking/protocol/models/PageAdapterFactoryTest.kt
+++ b/core/networking/src/test/kotlin/com/kelsos/mbrc/core/networking/protocol/models/PageAdapterFactoryTest.kt
@@ -1,0 +1,48 @@
+package com.kelsos.mbrc.core.networking.protocol.models
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import org.junit.Test
+
+class PageAdapterFactoryTest {
+
+  private val moshi = Moshi.Builder().add(PageAdapterFactory).build()
+  private val type = Types.newParameterizedType(Page::class.java, String::class.java)
+  private val adapter = moshi.adapter<Page<String>>(type)
+
+  @Test
+  fun `parses a normal page payload`() {
+    val page = adapter.fromJson(
+      """{"total":2,"offset":0,"limit":10,"data":["a","b"]}"""
+    )
+
+    assertThat(page).isNotNull()
+    assertThat(page!!.total).isEqualTo(2)
+    assertThat(page.offset).isEqualTo(0)
+    assertThat(page.limit).isEqualTo(10)
+    assertThat(page.data).containsExactly("a", "b").inOrder()
+  }
+
+  @Test
+  fun `treats a bare empty array as a terminal empty page`() {
+    val page = adapter.fromJson("""[]""")
+
+    assertThat(page).isNotNull()
+    assertThat(page!!.total).isEqualTo(0)
+    assertThat(page.offset).isEqualTo(0)
+    assertThat(page.data).isEmpty()
+    // ApiBase.getAllPages breaks when offset + limit > total. The synthetic
+    // page must satisfy that so pagination terminates instead of looping.
+    assertThat(page.offset + page.limit).isGreaterThan(page.total)
+  }
+
+  @Test
+  fun `treats a non-empty top-level array as a terminal empty page`() {
+    val page = adapter.fromJson("""["unexpected","payload"]""")
+
+    assertThat(page).isNotNull()
+    assertThat(page!!.data).isEmpty()
+    assertThat(page.offset + page.limit).isGreaterThan(page.total)
+  }
+}


### PR DESCRIPTION
## Summary
Some servers return a bare JSON array (e.g. \`[]\`) where the \`Page<T>\` object is expected. The generated \`PageJsonAdapter\` throws \`JsonDataException: Expected BEGIN_OBJECT but was BEGIN_ARRAY\` and aborts pagination in \`ApiBase.getAllPages\`.

- Adds a Moshi \`JsonAdapter.Factory\` for \`Page<*>\` that peeks the first token.
- On \`BEGIN_ARRAY\` it skips the array and returns a synthetic terminal page (\`limit = 1\`) so \`offset + limit > total\` fires immediately and the paging loop exits cleanly. Other shapes delegate to the generated adapter unchanged.
- Registered in \`AppModule\`'s global \`Moshi\`.

## Test plan
- [x] \`./gradlew :core:networking:testDebugUnitTest\` — new \`PageAdapterFactoryTest\` covers normal object, empty array, and unexpected non-empty array; asserts loop-termination invariant.
- [x] \`./gradlew staticAnalysisAll\` clean.