### PR TITLE
feat(library): restore sync action on the library top app bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@ Changelog
 -----------
 
 ## [Unreleased]
+### Added
+- Restores the sync action on the library top app bar, so a sync can be triggered without going through the empty-state button or settings.
+
 ### Fixed
 - Fixes accidental track removal while scrolling the now playing queue. Swipe-to-remove now triggers only on a deliberate right-to-left swipe, and Remove is also available from the row's overflow menu as a discoverable alternative. Reordering is now started from the drag handle on the right side of each row, so it no longer competes with scrolling or swiping.
 - Fixes the left-edge swipe-to-open gesture for the navigation drawer not working on the now playing screen.
 - Fixes the now playing queue capping at 100 items: only the first page ever loaded because `LazyPagingItems` was iterated indirectly. The queue now enables placeholders and iterates `LazyPagingItems` directly so Paging 3 keeps loading subsequent pages on scroll.
 - Fixes pull-to-refresh not triggering when the now playing queue is empty by wrapping the empty/loading/error states in a vertically scrollable container.
 - Fixes drag-and-drop reorder being snapped back to the server order when a new page lands mid-drag, and lets users reorder across page boundaries by guarding mid-drag refreshes with a settle window and resolving the source index against the displayed list.
+- Fixes a crash when the server returns a bare empty array instead of an empty page object for paged library responses; pagination now terminates cleanly on that response shape.
 
 ## [1.6.0-rc.4] - 2026-04-22
 ### Fixed

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -3,11 +3,13 @@
   <version
     version="Unreleased"
     release="">
+    <feature>Restores the sync action on the library top app bar, so a sync can be triggered without going through the empty-state button or settings.</feature>
     <bug>Fixes accidental track removal while scrolling the now playing queue: swipe-to-remove now triggers only on a deliberate right-to-left swipe, Remove is also available from the row overflow menu, and reorder is started from the drag handle on the right of each row.</bug>
     <bug>Fixes the left-edge swipe-to-open gesture for the navigation drawer not working on the now playing screen.</bug>
     <bug>Fixes the now playing queue capping at 100 items so the full queue is reachable on scroll.</bug>
     <bug>Fixes pull-to-refresh not triggering when the now playing queue is empty.</bug>
     <bug>Fixes drag-and-drop reorder snapping back when a new page loaded mid-drag, and now lets users reorder across page boundaries.</bug>
+    <bug>Fixes a crash when the server returned a bare empty array for paged library responses; pagination now terminates cleanly.</bug>
   </version>
   <version
     version="1.6.0-rc.4"

--- a/feature/library/src/main/kotlin/com/kelsos/mbrc/feature/library/compose/LibraryScreen.kt
+++ b/feature/library/src/main/kotlin/com/kelsos/mbrc/feature/library/compose/LibraryScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.automirrored.filled.ViewList
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
@@ -184,6 +185,7 @@ fun LibraryScreen(
   val searchDescription = stringResource(R.string.library_search_hint)
   val sortDescription = stringResource(R.string.sort_button_description)
   val viewModeDescription = stringResource(R.string.album_view_mode_description)
+  val syncDescription = stringResource(R.string.library_action__sync)
   val isAlbumsTab = pagerState.currentPage == LibraryTab.ALBUMS.ordinal
   val actionItems = remember(isSearchActive, syncProgress.running, isAlbumsTab, isGridMode) {
     if (!isSearchActive && !syncProgress.running) {
@@ -197,6 +199,13 @@ fun LibraryScreen(
             )
           )
         }
+        add(
+          ActionItem(
+            icon = Icons.Default.Sync,
+            contentDescription = syncDescription,
+            onClick = { viewModel.sync() }
+          )
+        )
         add(
           ActionItem(
             icon = Icons.AutoMirrored.Filled.Sort,

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
   <string name="library__sync_complete">Sync completed successfully. %1$s , %2$s, %3$s, %4$s and %5$s are available.</string>
   <string name="library__sync_failed">The library metadata sync was incomplete or failed completely. This might result in queueing not working properly..</string>
   <string name="library__sync_progress">Syncing %1$d of %2$d %3$s</string>
+  <string name="library_action__sync">Sync library</string>
   <string name="library_album_artists_only">Only Album Artists</string>
   <string name="library_menu__sync_state">Library Sync State</string>
   <string name="library_search_hint">Search your library</string>


### PR DESCRIPTION
## Summary
Restores a sync affordance to the library top app bar. Users previously had to rely on the empty-state button or hunt through settings to trigger a sync — the toolbar action is the historical (and expected) UX.

- Adds an \`ActionItem\` with \`Icons.Default.Sync\` wired to \`LibraryViewModel.sync()\`.
- Hidden during search and while a sync is already running (the top bar shows progress in that state).
- New string: \`library_action__sync\` = "Sync library".

## Test plan
- [x] \`./gradlew staticAnalysisAll\`
- [x] \`./gradlew :feature:library:testDebugUnitTest\`
- [x] \`./gradlew :app:validateGithubDebugScreenshotTest\`
- [ ] On-device: tap the sync icon — confirm sync starts and the toolbar switches to the progress state.