### PR TITLE
fix(networking): discover every MusicBee host on the LAN in one scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 ### Added
 - Restores the sync action on the library top app bar, so a sync can be triggered without going through the empty-state button or settings.
 - Adds a visible delete button (next to edit) on each connection row in the connection manager, gated by a confirmation dialog. The existing swipe-to-delete gesture is preserved as a power-user shortcut.
+- Network discovery now finds every MusicBee plugin on the LAN on the first scan instead of just one. The scan listens for a few seconds, re-broadcasts the discovery packet to combat multicast packet loss, and de-duplicates results by address.
 
 ### Fixed
 - Fixes accidental track removal while scrolling the now playing queue. Swipe-to-remove now triggers only on a deliberate right-to-left swipe, and Remove is also available from the row's overflow menu as a discoverable alternative. Reordering is now started from the drag handle on the right side of each row, so it no longer competes with scrolling or swiping.

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -5,6 +5,7 @@
     release="">
     <feature>Restores the sync action on the library top app bar, so a sync can be triggered without going through the empty-state button or settings.</feature>
     <feature>Adds a visible delete button on each connection row in the connection manager, with a confirmation dialog. Swipe-to-delete still works for power users.</feature>
+    <feature>Network discovery now finds every MusicBee plugin on the LAN in a single scan, with re-broadcasts to combat multicast packet loss.</feature>
     <bug>Fixes accidental track removal while scrolling the now playing queue: swipe-to-remove now triggers only on a deliberate right-to-left swipe, Remove is also available from the row overflow menu, and reorder is started from the drag handle on the right of each row.</bug>
     <bug>Fixes the left-edge swipe-to-open gesture for the navigation drawer not working on the now playing screen.</bug>
     <bug>Fixes the now playing queue capping at 100 items so the full queue is reachable on scroll.</bug>

--- a/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/ClientConnectionManager.kt
+++ b/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/ClientConnectionManager.kt
@@ -251,10 +251,9 @@ class ClientConnectionManagerImpl(
   private suspend fun discoverConnection() = connectionProvider.discover().let { discoveryStop ->
     when (discoveryStop) {
       is DiscoveryStop.Complete -> {
-        Timber.v(
-          "Discovery detected ${discoveryStop.settings.address} will attempt to connect to it"
-        )
-        discoveryStop.settings
+        val host = discoveryStop.first
+        Timber.v("Discovery detected ${host.address} will attempt to connect to it")
+        host
       }
 
       else -> {

--- a/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/discovery/DiscoveryStop.kt
+++ b/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/discovery/DiscoveryStop.kt
@@ -7,5 +7,16 @@ sealed class DiscoveryStop {
 
   object NotFound : DiscoveryStop()
 
-  class Complete(val settings: ConnectionSettings) : DiscoveryStop()
+  /**
+   * Discovery succeeded and found at least one MusicBee host. [settings]
+   * is guaranteed non-empty and de-duplicated by address.
+   */
+  class Complete(val settings: List<ConnectionSettings>) : DiscoveryStop() {
+    init {
+      require(settings.isNotEmpty()) { "Complete requires at least one connection" }
+    }
+
+    /** First host found, used by single-host callers (e.g. auto-connect). */
+    val first: ConnectionSettings get() = settings.first()
+  }
 }

--- a/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/discovery/RemoteServiceDiscovery.kt
+++ b/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/discovery/RemoteServiceDiscovery.kt
@@ -13,6 +13,7 @@ import java.net.MulticastSocket
 import java.net.NetworkInterface
 import java.net.SocketException
 import java.net.SocketTimeoutException
+import kotlinx.coroutines.yield
 import okio.buffer
 import okio.source
 import timber.log.Timber
@@ -77,29 +78,62 @@ class RemoteServiceDiscoveryImpl(
     }
   }
 
-  private fun retryUntilNotifyContext(
-    socket: MulticastSocket,
-    maxAttempts: Int = 3,
-    totalTimeoutMs: Long = 15000
-  ): DiscoveryMessage? {
-    var attempts = 0
+  /**
+   * Collects every unique NOTIFY response that arrives within
+   * [COLLECTION_WINDOW_MS]. Re-broadcasts the discovery packet every
+   * [REBROADCAST_INTERVAL_MS] to combat UDP/multicast packet loss on
+   * multi-host LANs (the original single-broadcast scan often missed
+   * peers on the first try). De-duplicates by `(address, port)`.
+   *
+   * Returns early [POST_FIRST_GATHER_MS] after the first NOTIFY arrives
+   * — siblings on the same LAN typically answer within ~1s of each
+   * other, so the full 4s window is only paid when nobody answers.
+   * This keeps the auto-connect cold-start path fast.
+   *
+   * Co-operative cancellation: [yield] is called between socket reads
+   * so a cancelled caller (screen left, scope torn down) doesn't pin
+   * the network thread for the rest of the window.
+   */
+  private suspend fun collectNotifyMessages(socket: MulticastSocket): List<DiscoveryMessage> {
+    val found = LinkedHashMap<Pair<String, Int>, DiscoveryMessage>()
     val startTime = System.currentTimeMillis()
-    val responses = mutableListOf<DiscoveryMessage>()
+    var firstResponseAt: Long? = null
+    var lastBroadcast = startTime
 
-    while (attempts < maxAttempts && System.currentTimeMillis() - startTime < totalTimeoutMs) {
+    while (true) {
+      yield()
+      val now = System.currentTimeMillis()
+      if (now - startTime >= COLLECTION_WINDOW_MS) break
+      if (firstResponseAt != null && now - firstResponseAt >= POST_FIRST_GATHER_MS) break
+
       val message = getDiscoveryMessage(socket)
-      if (message != null) {
-        responses.add(message)
-        if (message.context == NOTIFY) {
-          Timber.v("Found notify message after %d attempts", attempts + 1)
-          return message
+      if (message != null && message.context == NOTIFY) {
+        val isNew = found.putIfAbsent(message.address to message.port, message) == null
+        if (isNew && firstResponseAt == null) {
+          firstResponseAt = System.currentTimeMillis()
         }
       }
-      attempts++
-      Timber.v("Discovery attempt: %s, responses so far: %d", attempts, responses.size)
+      if (System.currentTimeMillis() - lastBroadcast >= REBROADCAST_INTERVAL_MS) {
+        rebroadcastDiscovery(socket)
+        lastBroadcast = System.currentTimeMillis()
+      }
     }
 
-    return responses.firstOrNull { it.context == NOTIFY }
+    Timber.v("Discovery window closed, %d unique host(s) found", found.size)
+    return found.values.toList()
+  }
+
+  private fun rebroadcastDiscovery(socket: MulticastSocket) {
+    val address = getWifiAddress() ?: return
+    val data = adapter.toJson(
+      DiscoveryMessage(context = Protocol.DISCOVERY, address = address)
+    ).toByteArray()
+    try {
+      val group = InetAddress.getByName(DISCOVERY_ADDRESS)
+      socket.send(DatagramPacket(data, data.size, group, MULTICAST_PORT))
+    } catch (e: IOException) {
+      Timber.v(e, "Re-broadcast failed; will rely on already-collected responses")
+    }
   }
 
   override suspend fun discover(): DiscoveryStop {
@@ -118,10 +152,10 @@ class RemoteServiceDiscoveryImpl(
   private suspend fun waitForServiceNotification(): DiscoveryStop {
     return useMulticastLock(manager.createMulticastLock("locked")) {
       useMulticastSocket { socket ->
-        val message = retryUntilNotifyContext(socket)
+        val messages = collectNotifyMessages(socket)
 
-        return@useMulticastSocket if (message?.context == NOTIFY) {
-          DiscoveryStop.Complete(message.toConnection())
+        return@useMulticastSocket if (messages.isNotEmpty()) {
+          DiscoveryStop.Complete(messages.map { it.toConnection() })
         } else {
           DiscoveryStop.NotFound
         }
@@ -197,8 +231,25 @@ class RemoteServiceDiscoveryImpl(
   companion object {
     private const val BUFFER_SIZE = 1024
     private const val NOTIFY = "notify"
-    private const val RESPONSE_TIMEOUT = 2000
+    private const val RESPONSE_TIMEOUT = 500
     private const val MULTICAST_PORT = 45345
     private const val DISCOVERY_ADDRESS = "239.1.5.10"
+
+    // Maximum time the receiver listens for NOTIFY messages on a single
+    // scan when nobody has answered yet. Long enough for slow first
+    // responders without making the no-host case painful.
+    private const val COLLECTION_WINDOW_MS = 4000L
+
+    // Once the first NOTIFY has arrived, the loop keeps listening for
+    // this much longer to collect siblings on multi-host LANs, then
+    // returns. Tuned so single-host auto-connect doesn't pay the full
+    // COLLECTION_WINDOW_MS and so peers responding to the same broadcast
+    // (which generally answer within a few hundred ms of each other) all
+    // make it into the result.
+    private const val POST_FIRST_GATHER_MS = 1000L
+
+    // How often the discovery packet is re-broadcast inside the collection
+    // window so a single dropped multicast packet doesn't hide a host.
+    private const val REBROADCAST_INTERVAL_MS = 1000L
   }
 }

--- a/feature/settings/src/main/kotlin/com/kelsos/mbrc/feature/settings/compose/ConnectionManagerScreen.kt
+++ b/feature/settings/src/main/kotlin/com/kelsos/mbrc/feature/settings/compose/ConnectionManagerScreen.kt
@@ -109,7 +109,7 @@ fun ConnectionManagerScreen(
   val addLabel = stringResource(R.string.common_add)
   val noWifiMessage = stringResource(R.string.connection_manager_discovery_no_wifi)
   val notFoundMessage = stringResource(R.string.connection_manager_discovery_not_found)
-  val successMessage = stringResource(R.string.connection_manager_discovery_success)
+  val context = androidx.compose.ui.platform.LocalContext.current
   val portErrorMessage = stringResource(R.string.connection_manager_port_error)
 
   // Compute FAB state inline
@@ -139,8 +139,14 @@ fun ConnectionManagerScreen(
     viewModel.discoveryEvents.collect { event ->
       val message = when (event) {
         DiscoveryStop.NoWifi -> noWifiMessage
+
         DiscoveryStop.NotFound -> notFoundMessage
-        is DiscoveryStop.Complete -> successMessage
+
+        is DiscoveryStop.Complete -> context.resources.getQuantityString(
+          R.plurals.connection_manager_discovery_success_count,
+          event.settings.size,
+          event.settings.size
+        )
       }
       snackbarHostState.showSnackbar(message)
     }

--- a/feature/settings/src/main/kotlin/com/kelsos/mbrc/feature/settings/domain/ConnectionRepository.kt
+++ b/feature/settings/src/main/kotlin/com/kelsos/mbrc/feature/settings/domain/ConnectionRepository.kt
@@ -8,8 +8,10 @@ import com.kelsos.mbrc.core.data.settings.ConnectionDao
 import com.kelsos.mbrc.core.data.settings.ConnectionSettingsEntity
 import com.kelsos.mbrc.core.networking.discovery.DiscoveryStop
 import com.kelsos.mbrc.core.networking.discovery.RemoteServiceDiscovery
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 
 interface ConnectionRepository {
   suspend fun save(settings: ConnectionSettings)
@@ -35,7 +37,30 @@ class ConnectionRepositoryImpl(
   override suspend fun discover(): DiscoveryStop {
     val discover = discovery.discover()
     if (discover is DiscoveryStop.Complete) {
-      save(discover.settings)
+      discover.settings.forEach { host ->
+        // Skip hosts already saved with the same (address, port) — repeated
+        // scans should not produce duplicate rows. Any other save failure
+        // is logged so one bad host doesn't drop the rest of the batch.
+        val existingId = withContext(dispatchers.database) {
+          dao.findId(host.address, host.port)
+        }
+        if (existingId != null) {
+          Timber.v(
+            "Discovered host %s:%d already saved (id=%d)",
+            host.address,
+            host.port,
+            existingId
+          )
+          return@forEach
+        }
+        try {
+          save(host)
+        } catch (e: CancellationException) {
+          throw e
+        } catch (e: Exception) {
+          Timber.w(e, "Failed to save discovered host %s:%d", host.address, host.port)
+        }
+      }
     }
     return discover
   }

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -26,7 +26,10 @@
   <string name="connection_manager_delete_confirm_message">%1$s will be removed. This can\'t be undone.</string>
   <string name="connection_manager_discovery_no_wifi">No WiFi connection available</string>
   <string name="connection_manager_discovery_not_found">No MusicBee plugin found on network</string>
-  <string name="connection_manager_discovery_success">Successfully discovered MusicBee plugin</string>
+  <plurals name="connection_manager_discovery_success_count">
+    <item quantity="one">Discovered %d MusicBee plugin on the network</item>
+    <item quantity="other">Discovered %d MusicBee plugins on the network</item>
+  </plurals>
   <string name="connection_manager_edit_connection">Edit Connection</string>
   <string name="connection_manager_error_loading">Error loading connections</string>
   <string name="connection_manager_no_connections">No connections configured</string>

--- a/feature/settings/src/test/kotlin/com/kelsos/mbrc/feature/settings/ConnectionManagerViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/com/kelsos/mbrc/feature/settings/ConnectionManagerViewModelTest.kt
@@ -271,7 +271,7 @@ class ConnectionManagerViewModelTest : KoinTest {
       isDefault = false,
       id = 0
     )
-    coEvery { repository.discover() } returns DiscoveryStop.Complete(discoveredConnection)
+    coEvery { repository.discover() } returns DiscoveryStop.Complete(listOf(discoveredConnection))
 
     viewModel.discoveryEvents.test {
       viewModel.startScanning()
@@ -279,7 +279,7 @@ class ConnectionManagerViewModelTest : KoinTest {
 
       val event = awaitItem()
       assertThat(event).isInstanceOf(DiscoveryStop.Complete::class.java)
-      assertThat((event as DiscoveryStop.Complete).settings).isEqualTo(discoveredConnection)
+      assertThat((event as DiscoveryStop.Complete).settings).containsExactly(discoveredConnection)
     }
   }
 


### PR DESCRIPTION
## Summary
- `DiscoveryStop.Complete` now carries a `List<ConnectionSettings>` (deduped by address+port) instead of a single host, so a single scan can return every MusicBee plugin reachable on the LAN.
- `RemoteServiceDiscovery` listens for a ~4s collection window with periodic re-broadcasts to combat multicast packet loss. Once at least one host has responded it short-circuits ~1s later to keep cold-start auto-connect snappy. Loop yields per iteration for cooperative cancellation.
- `ConnectionRepositoryImpl.discover()` iterates the list, skips hosts already saved via `dao.findId(address, port)`, and isolates per-host `save()` failures so one bad host doesn't drop the batch (`CancellationException` is rethrown).
- `ClientConnectionManager.discoverConnection()` uses the new list's first entry.
- Snackbar string switched to a plurals entry: "Discovered N MusicBee plugin(s)…". Old singular string removed.

## Why
A tester on a multi-host LAN reported that the scan only found one plugin on the first try, sometimes more on retry. Root cause: `retryUntilNotifyContext` returned on the first NOTIFY and `DiscoveryStop.Complete` carried a single connection, so multicast packet loss made the first scan unreliable.

## Test plan
- [x] `./gradlew verifyLocal` green
- [x] Single-host scan: snackbar reads "Discovered 1 MusicBee plugin", host appears in list
- [x] Multi-host scan: snackbar pluralizes with N hosts, all appear in list
- [x] Re-scan with hosts already saved: no duplicate rows added
- [x] Cancel mid-scan ends promptly
- [x] Cold-start auto-discovery connects shortly after first host responds (not after the full 4s)