### PR TITLE
fix(networking): bound socket message flow to prevent OOM under burst load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog
 - Fixes pull-to-refresh not triggering when the now playing queue is empty by wrapping the empty/loading/error states in a vertically scrollable container.
 - Fixes drag-and-drop reorder being snapped back to the server order when a new page lands mid-drag, and lets users reorder across page boundaries by guarding mid-drag refreshes with a settle window and resolving the source index against the displayed list.
 - Fixes a crash when the server returns a bare empty array instead of an empty page object for paged library responses; pagination now terminates cleanly on that response shape.
+- Fixes an out-of-memory crash on the socket message pipeline under burst load. The incoming-message flow now uses a bounded buffer that drops the oldest queued message when a downstream collector falls behind, instead of spawning unbounded coroutines per message.
 
 ## [1.6.0-rc.4] - 2026-04-22
 ### Fixed

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -12,6 +12,7 @@
     <bug>Fixes pull-to-refresh not triggering when the now playing queue is empty.</bug>
     <bug>Fixes drag-and-drop reorder snapping back when a new page loaded mid-drag, and now lets users reorder across page boundaries.</bug>
     <bug>Fixes a crash when the server returned a bare empty array for paged library responses; pagination now terminates cleanly.</bug>
+    <bug>Fixes an out-of-memory crash on the socket message pipeline by bounding the incoming-message buffer and dropping the oldest queued message under burst load.</bug>
   </version>
   <version
     version="1.6.0-rc.4"

--- a/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/ClientConnectionManager.kt
+++ b/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/ClientConnectionManager.kt
@@ -17,6 +17,7 @@ import java.net.SocketTimeoutException
 import kotlin.math.pow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -406,7 +407,10 @@ class Connection(
   private val adapter = moshi.adapter(SocketMessage::class.java)
   private val job = SupervisorJob()
   private val scope = CoroutineScope(job + dispatchers.io)
-  private val _messages = MutableSharedFlow<SocketMessage>()
+  private val _messages = MutableSharedFlow<SocketMessage>(
+    extraBufferCapacity = MESSAGE_BUFFER_CAPACITY,
+    onBufferOverflow = BufferOverflow.DROP_OLDEST
+  )
   val messages: Flow<SocketMessage> get() = _messages
 
   @Volatile
@@ -487,9 +491,7 @@ class Connection(
             return@runCatching
           }
 
-          scope.launch {
-            _messages.emit(message)
-          }
+          _messages.tryEmit(message)
         }
 
       if (result.isFailure) {
@@ -554,6 +556,7 @@ class Connection(
     internal const val CONNECT_TIMEOUT = 15_000
     private const val NEWLINE = "\r\n"
     private const val MAX_PARSE_FAILURES = 5
+    private const val MESSAGE_BUFFER_CAPACITY = 128
 
     fun connect(address: SocketAddress): Socket {
       val socket = Socket()


### PR DESCRIPTION
## Summary
- `Connection._messages` (the `MutableSharedFlow<SocketMessage>` carrying every incoming socket message) used the default zero buffer with SUSPEND-on-overflow, and `emitMessages` wrapped `emit()` in `scope.launch` to avoid suspending the blocking socket-read loop.
- Under burst load with any slow downstream collector, each emit spawned a coroutine that suspended inside `emitSuspend`. Coroutines piled up on the dispatcher queue, each pinning a `SocketMessage` and continuation chain, until the heap was exhausted.
- Switch the flow to a bounded 128-slot buffer with `BufferOverflow.DROP_OLDEST` and replace `scope.launch { emit(...) }` with synchronous `tryEmit(...)`. With DROP_OLDEST, `tryEmit` always succeeds and the oldest unconsumed message is dropped when collectors fall behind.

## Why
Real production OOM crash reported via a device crash trace:
```
java.lang.OutOfMemoryError: Failed to allocate a 48 byte allocation with 1728 free bytes ...
    kotlinx.coroutines.flow.SharedFlowImpl.emitSuspend(SharedFlow.kt:761)
    kotlinx.coroutines.flow.SharedFlowImpl.emit\$suspendImpl(SharedFlow.kt:420)
    com.kelsos.mbrc.core.networking.Connection\$emitMessages\$result\$1\$1.invokeSuspend(ClientConnectionManager.kt:492)
```

Dropping the oldest message under sustained backpressure is acceptable here because messages are intermediate status updates (track-change broadcasts, queue snapshots, protocol acks) — the next message supersedes the previous one for the same channel. If logs show drops in normal operation post-fix, the right next move is to profile the slow collector, not to grow the buffer.

## Test plan
- [x] \`./gradlew verifyLocal\` green
- [ ] Soak test: long-running connection through a heavy library sync, no OOM
- [ ] Confirm message delivery still works end-to-end (playback control, track-change updates)