### PR TITLE
fix(navigation): don't crash on titles containing %, and clean up route arg encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Changelog
 - Fixes drag-and-drop reorder being snapped back to the server order when a new page lands mid-drag, and lets users reorder across page boundaries by guarding mid-drag refreshes with a settle window and resolving the source index against the displayed list.
 - Fixes a crash when the server returns a bare empty array instead of an empty page object for paged library responses; pagination now terminates cleanly on that response shape.
 - Fixes an out-of-memory crash on the socket message pipeline under burst load. The incoming-message flow now uses a bounded buffer that drops the oldest queued message when a downstream collector falls behind, instead of spawning unbounded coroutines per message.
-- Fixes an `IllegalArgumentException` crash when navigating into an album, artist, or genre whose name contains a literal `%`, `&`, or `+`. Navigation route arguments are now URL-decoded defensively, falling back to the raw value if decoding fails.
+- Fixes an `IllegalArgumentException` crash when navigating into an album, artist, or genre whose name contains a literal `%` (e.g. "100% Hits"). Route arguments are now encoded with `Uri.encode` and consumed directly from the navigation back stack, removing the duplicate `URLDecoder.decode` step that caused the crash.
 
 ## [1.6.0-rc.4] - 2026-04-22
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changelog
 - Fixes drag-and-drop reorder being snapped back to the server order when a new page lands mid-drag, and lets users reorder across page boundaries by guarding mid-drag refreshes with a settle window and resolving the source index against the displayed list.
 - Fixes a crash when the server returns a bare empty array instead of an empty page object for paged library responses; pagination now terminates cleanly on that response shape.
 - Fixes an out-of-memory crash on the socket message pipeline under burst load. The incoming-message flow now uses a bounded buffer that drops the oldest queued message when a downstream collector falls behind, instead of spawning unbounded coroutines per message.
+- Fixes an `IllegalArgumentException` crash when navigating into an album, artist, or genre whose name contains a literal `%`, `&`, or `+`. Navigation route arguments are now URL-decoded defensively, falling back to the raw value if decoding fails.
 
 ## [1.6.0-rc.4] - 2026-04-22
 ### Fixed

--- a/app/src/main/kotlin/com/kelsos/mbrc/ui/AppNavGraph.kt
+++ b/app/src/main/kotlin/com/kelsos/mbrc/ui/AppNavGraph.kt
@@ -1,5 +1,6 @@
 package com.kelsos.mbrc.ui
 
+import android.net.Uri
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
@@ -26,9 +27,6 @@ import com.kelsos.mbrc.feature.settings.compose.AppLicenseScreen
 import com.kelsos.mbrc.feature.settings.compose.ConnectionManagerScreen
 import com.kelsos.mbrc.feature.settings.compose.LicensesScreen
 import com.kelsos.mbrc.feature.settings.compose.SettingsScreen
-import java.net.URLDecoder
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 
@@ -52,12 +50,12 @@ fun AppNavGraph(
       PlayerScreen(
         onNavigateToNowPlaying = { navController.navigate(Screen.NowPlayingList.route) },
         onNavigateToAlbum = { album, artist ->
-          val encodedAlbum = URLEncoder.encode(album, StandardCharsets.UTF_8.toString())
-          val encodedArtist = URLEncoder.encode(artist, StandardCharsets.UTF_8.toString())
+          val encodedAlbum = Uri.encode(album)
+          val encodedArtist = Uri.encode(artist)
           navController.navigate("album_tracks/0/$encodedAlbum/$encodedArtist")
         },
         onNavigateToArtist = { artist ->
-          val encodedName = URLEncoder.encode(artist, StandardCharsets.UTF_8.toString())
+          val encodedName = Uri.encode(artist)
           navController.navigate("artist_albums/0/$encodedName")
         },
         snackbarHostState = snackbarHostState,
@@ -69,20 +67,20 @@ fun AppNavGraph(
       LibraryScreen(
         onOpenDrawer = onOpenDrawer,
         onNavigateToGenreArtists = { genre ->
-          val encodedName = URLEncoder.encode(genre.genre, StandardCharsets.UTF_8.toString())
+          val encodedName = Uri.encode(genre.genre)
           navController.navigate("genre_artists/${genre.id}/$encodedName")
         },
         onNavigateToGenreAlbums = { genre ->
-          val encodedName = URLEncoder.encode(genre.genre, StandardCharsets.UTF_8.toString())
+          val encodedName = Uri.encode(genre.genre)
           navController.navigate("genre_albums/${genre.id}/$encodedName")
         },
         onNavigateToArtistAlbums = { artist ->
-          val encodedName = URLEncoder.encode(artist.artist, StandardCharsets.UTF_8.toString())
+          val encodedName = Uri.encode(artist.artist)
           navController.navigate("artist_albums/${artist.id}/$encodedName")
         },
         onNavigateToAlbumTracks = { album ->
-          val encodedAlbum = URLEncoder.encode(album.album, StandardCharsets.UTF_8.toString())
-          val encodedArtist = URLEncoder.encode(album.artist, StandardCharsets.UTF_8.toString())
+          val encodedAlbum = Uri.encode(album.album)
+          val encodedArtist = Uri.encode(album.artist)
           navController.navigate("album_tracks/${album.id}/$encodedAlbum/$encodedArtist")
         },
         onNavigateToPlayer = { navController.navigate(Screen.Home.route) },
@@ -139,8 +137,8 @@ fun AppNavGraph(
         navArgument("artist") { type = NavType.StringType }
       )
     ) { backStackEntry ->
-      val album = safeUrlDecode(backStackEntry.arguments?.getString("album").orEmpty())
-      val artist = safeUrlDecode(backStackEntry.arguments?.getString("artist").orEmpty())
+      val album = backStackEntry.arguments?.getString("album").orEmpty()
+      val artist = backStackEntry.arguments?.getString("artist").orEmpty()
       val albumInfo = AlbumInfo(album = album, artist = artist, cover = null)
       AlbumTracksScreen(
         albumInfo = albumInfo,
@@ -157,13 +155,13 @@ fun AppNavGraph(
         navArgument("artistName") { type = NavType.StringType }
       )
     ) { backStackEntry ->
-      val artistName = safeUrlDecode(backStackEntry.arguments?.getString("artistName").orEmpty())
+      val artistName = backStackEntry.arguments?.getString("artistName").orEmpty()
       ArtistAlbumsScreen(
         artistName = artistName,
         onNavigateBack = { navController.popBackStack() },
         onNavigateToAlbumTracks = { album ->
-          val encodedAlbum = URLEncoder.encode(album.album, StandardCharsets.UTF_8.toString())
-          val encodedArtist = URLEncoder.encode(album.artist, StandardCharsets.UTF_8.toString())
+          val encodedAlbum = Uri.encode(album.album)
+          val encodedArtist = Uri.encode(album.artist)
           navController.navigate("album_tracks/${album.id}/$encodedAlbum/$encodedArtist")
         },
         onNavigateToPlayer = { navController.navigate(Screen.Home.route) },
@@ -179,13 +177,13 @@ fun AppNavGraph(
       )
     ) { backStackEntry ->
       val genreId = backStackEntry.arguments?.getLong("genreId") ?: 0L
-      val genreName = safeUrlDecode(backStackEntry.arguments?.getString("genreName").orEmpty())
+      val genreName = backStackEntry.arguments?.getString("genreName").orEmpty()
       GenreArtistsScreen(
         genreId = genreId,
         genreName = genreName,
         onNavigateBack = { navController.popBackStack() },
         onNavigateToArtistAlbums = { artist ->
-          val encodedName = URLEncoder.encode(artist.artist, StandardCharsets.UTF_8.toString())
+          val encodedName = Uri.encode(artist.artist)
           navController.navigate("artist_albums/${artist.id}/$encodedName")
         },
         onNavigateToPlayer = { navController.navigate(Screen.Home.route) },
@@ -201,14 +199,14 @@ fun AppNavGraph(
       )
     ) { backStackEntry ->
       val genreId = backStackEntry.arguments?.getLong("genreId") ?: 0L
-      val genreName = safeUrlDecode(backStackEntry.arguments?.getString("genreName").orEmpty())
+      val genreName = backStackEntry.arguments?.getString("genreName").orEmpty()
       GenreAlbumsScreen(
         genreId = genreId,
         genreName = genreName,
         onNavigateBack = { navController.popBackStack() },
         onNavigateToAlbumTracks = { album ->
-          val encodedAlbum = URLEncoder.encode(album.album, StandardCharsets.UTF_8.toString())
-          val encodedArtist = URLEncoder.encode(album.artist, StandardCharsets.UTF_8.toString())
+          val encodedAlbum = Uri.encode(album.album)
+          val encodedArtist = Uri.encode(album.artist)
           navController.navigate("album_tracks/${album.id}/$encodedAlbum/$encodedArtist")
         },
         onNavigateToPlayer = { navController.navigate(Screen.Home.route) },
@@ -228,11 +226,8 @@ fun AppNavGraph(
           scope.launch {
             val track = trackRepository.getByPath(path)
             if (track != null && track.album.isNotBlank()) {
-              val encodedAlbum = URLEncoder.encode(track.album, StandardCharsets.UTF_8.toString())
-              val encodedArtist = URLEncoder.encode(
-                track.albumArtist.ifBlank { track.artist },
-                StandardCharsets.UTF_8.toString()
-              )
+              val encodedAlbum = Uri.encode(track.album)
+              val encodedArtist = Uri.encode(track.albumArtist.ifBlank { track.artist })
               navController.navigate("album_tracks/0/$encodedAlbum/$encodedArtist")
             } else {
               snackbarHostState.showSnackbar(trackNotFoundMessage)
@@ -240,7 +235,7 @@ fun AppNavGraph(
           }
         },
         onNavigateToArtist = { artist ->
-          val encodedName = URLEncoder.encode(artist, StandardCharsets.UTF_8.toString())
+          val encodedName = Uri.encode(artist)
           navController.navigate("artist_albums/0/$encodedName")
         },
         snackbarHostState = snackbarHostState
@@ -316,6 +311,3 @@ val drawerScreens = listOf(
   Screen.Settings,
   Screen.Help
 )
-
-private fun safeUrlDecode(value: String): String =
-  runCatching { URLDecoder.decode(value, StandardCharsets.UTF_8.toString()) }.getOrDefault(value)

--- a/app/src/main/kotlin/com/kelsos/mbrc/ui/AppNavGraph.kt
+++ b/app/src/main/kotlin/com/kelsos/mbrc/ui/AppNavGraph.kt
@@ -139,14 +139,8 @@ fun AppNavGraph(
         navArgument("artist") { type = NavType.StringType }
       )
     ) { backStackEntry ->
-      val album = URLDecoder.decode(
-        backStackEntry.arguments?.getString("album").orEmpty(),
-        StandardCharsets.UTF_8.toString()
-      )
-      val artist = URLDecoder.decode(
-        backStackEntry.arguments?.getString("artist").orEmpty(),
-        StandardCharsets.UTF_8.toString()
-      )
+      val album = safeUrlDecode(backStackEntry.arguments?.getString("album").orEmpty())
+      val artist = safeUrlDecode(backStackEntry.arguments?.getString("artist").orEmpty())
       val albumInfo = AlbumInfo(album = album, artist = artist, cover = null)
       AlbumTracksScreen(
         albumInfo = albumInfo,
@@ -163,10 +157,7 @@ fun AppNavGraph(
         navArgument("artistName") { type = NavType.StringType }
       )
     ) { backStackEntry ->
-      val artistName = URLDecoder.decode(
-        backStackEntry.arguments?.getString("artistName").orEmpty(),
-        StandardCharsets.UTF_8.toString()
-      )
+      val artistName = safeUrlDecode(backStackEntry.arguments?.getString("artistName").orEmpty())
       ArtistAlbumsScreen(
         artistName = artistName,
         onNavigateBack = { navController.popBackStack() },
@@ -188,10 +179,7 @@ fun AppNavGraph(
       )
     ) { backStackEntry ->
       val genreId = backStackEntry.arguments?.getLong("genreId") ?: 0L
-      val genreName = URLDecoder.decode(
-        backStackEntry.arguments?.getString("genreName").orEmpty(),
-        StandardCharsets.UTF_8.toString()
-      )
+      val genreName = safeUrlDecode(backStackEntry.arguments?.getString("genreName").orEmpty())
       GenreArtistsScreen(
         genreId = genreId,
         genreName = genreName,
@@ -213,10 +201,7 @@ fun AppNavGraph(
       )
     ) { backStackEntry ->
       val genreId = backStackEntry.arguments?.getLong("genreId") ?: 0L
-      val genreName = URLDecoder.decode(
-        backStackEntry.arguments?.getString("genreName").orEmpty(),
-        StandardCharsets.UTF_8.toString()
-      )
+      val genreName = safeUrlDecode(backStackEntry.arguments?.getString("genreName").orEmpty())
       GenreAlbumsScreen(
         genreId = genreId,
         genreName = genreName,
@@ -331,3 +316,6 @@ val drawerScreens = listOf(
   Screen.Settings,
   Screen.Help
 )
+
+private fun safeUrlDecode(value: String): String =
+  runCatching { URLDecoder.decode(value, StandardCharsets.UTF_8.toString()) }.getOrDefault(value)

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -13,7 +13,7 @@
     <bug>Fixes drag-and-drop reorder snapping back when a new page loaded mid-drag, and now lets users reorder across page boundaries.</bug>
     <bug>Fixes a crash when the server returned a bare empty array for paged library responses; pagination now terminates cleanly.</bug>
     <bug>Fixes an out-of-memory crash on the socket message pipeline by bounding the incoming-message buffer and dropping the oldest queued message under burst load.</bug>
-    <bug>Fixes a crash when navigating into an album, artist, or genre whose name contains a literal %, &amp;, or +.</bug>
+    <bug>Fixes a crash when navigating into an album, artist, or genre whose name contains a literal % (e.g. "100% Hits"). Route arguments now round-trip cleanly through the navigation back stack.</bug>
   </version>
   <version
     version="1.6.0-rc.4"

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -13,6 +13,7 @@
     <bug>Fixes drag-and-drop reorder snapping back when a new page loaded mid-drag, and now lets users reorder across page boundaries.</bug>
     <bug>Fixes a crash when the server returned a bare empty array for paged library responses; pagination now terminates cleanly.</bug>
     <bug>Fixes an out-of-memory crash on the socket message pipeline by bounding the incoming-message buffer and dropping the oldest queued message under burst load.</bug>
+    <bug>Fixes a crash when navigating into an album, artist, or genre whose name contains a literal %, &amp;, or +.</bug>
   </version>
   <version
     version="1.6.0-rc.4"

--- a/app/src/test/kotlin/com/kelsos/mbrc/ui/NavRouteEncodingTest.kt
+++ b/app/src/test/kotlin/com/kelsos/mbrc/ui/NavRouteEncodingTest.kt
@@ -1,0 +1,70 @@
+package com.kelsos.mbrc.ui
+
+import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Verifies that route argument values survive the encode -> path -> Uri.decode round-trip.
+ * navigation-compose runs `Uri.decode` on path arguments before exposing them via
+ * `backStackEntry.arguments?.getString(...)`, so the navigate-time encoding must be
+ * `Uri.encode` (not `URLEncoder.encode`, which uses `+` for space and is not undone by
+ * `Uri.decode`).
+ *
+ * Regression coverage for the prod `URLDecoder.decode: Illegal hex characters in escape (%) pattern`
+ * crash on titles containing `%`, `&`, or `+`.
+ */
+@RunWith(AndroidJUnit4::class)
+class NavRouteEncodingTest {
+  @Test
+  fun `round-trips title containing literal percent`() {
+    assertRoundTrip("100% Hits")
+  }
+
+  @Test
+  fun `round-trips title containing ampersand`() {
+    assertRoundTrip("Rock & Roll")
+  }
+
+  @Test
+  fun `round-trips title containing plus`() {
+    assertRoundTrip("C++ Classics")
+  }
+
+  @Test
+  fun `round-trips title containing forward slash`() {
+    assertRoundTrip("Rock/Pop")
+  }
+
+  @Test
+  fun `round-trips title containing spaces`() {
+    assertRoundTrip("Greatest Hits Of All Time")
+  }
+
+  @Test
+  fun `round-trips title containing unicode`() {
+    assertRoundTrip("Café del Mar — Ηχώ")
+  }
+
+  @Test
+  fun `round-trips title containing reserved nav characters together`() {
+    assertRoundTrip("100% & C++/Rock + Pop")
+  }
+
+  @Test
+  fun `Uri-encode of plain title is path-safe and contains no raw percent`() {
+    // Ensure a literal '%' in the source title is escaped to '%25' in the encoded form,
+    // i.e. the encoder does not leak unescaped reserved characters into the path.
+    val encoded = Uri.encode("100% Hits")
+    assertThat(encoded).doesNotContain("% ")
+    assertThat(encoded).contains("%25")
+  }
+
+  private fun assertRoundTrip(title: String) {
+    val encoded = Uri.encode(title)
+    val decoded = Uri.decode(encoded)
+    assertThat(decoded).isEqualTo(title)
+  }
+}


### PR DESCRIPTION
## Summary
- Replace `URLEncoder.encode(value, UTF_8)` with `Uri.encode(value)` at every navigate site in `AppNavGraph`.
- Drop the manual `URLDecoder.decode` at every retrieval site and consume `backStackEntry.arguments?.getString(...)` directly.
- The branch initially landed a defensive `runCatching` wrapper; that's now superseded by the structural fix in the second commit.
- Add `NavRouteEncodingTest` (AndroidJUnit4) covering round-trip for `%`, `&`, `+`, `/`, spaces, unicode, and a combined regression string.

## Why
`navigation-compose`'s `NavType.StringType` already URL-decodes path arguments at `arguments.getString(...)`. The previous code then ran `URLDecoder.decode` on top of that, which is a double-decode. For titles containing a literal `%`, the framework-decoded string contained a stray `%` that no longer matched `%XX` hex and `URLDecoder.decode` threw:

```
java.lang.IllegalArgumentException: URLDecoder: Illegal hex characters in escape (%) pattern : %&*
    java.net.URLDecoder.decode(URLDecoder.java:214)
    com.kelsos.mbrc.ui.AppNavGraphKt.AppNavGraph$lambda$1$0$11(AppNavGraph.kt:142)
```

Any user with an album/artist/genre named like "100% Hits" would crash on navigation.

`URLEncoder.encode` is also the wrong choice for path arguments: it uses `application/x-www-form-urlencoded`, which escapes space as `+`. `Uri.decode` (the decoder nav-compose uses internally) does not undo `+` to space, so the old code relied on the redundant `URLDecoder.decode` to fix up spaces. `Uri.encode` uses `%20` for spaces and is the right encoder for path segments — round-trip through nav-compose's auto-decode is now correct end-to-end.

## Test plan
- [x] `./gradlew verifyLocal` green
- [x] New unit tests (`NavRouteEncodingTest`) pass — covers `%`, `&`, `+`, `/`, space, unicode, combined
- [ ] On-device smoke: navigate into a title containing `%` (no crash), and one containing a space (renders correctly)