### PR TITLE
chore(release): bump to 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 -----------
 
-## [Unreleased]
+## [1.6.0] - 2026-06-01
 ### Added
 - Restores the sync action on the library top app bar, so a sync can be triggered without going through the empty-state button or settings.
 - Adds a visible delete button (next to edit) on each connection row in the connection manager, gated by a confirmation dialog. The existing swipe-to-delete gesture is preserved as a power-user shortcut.
@@ -285,7 +285,8 @@ Changelog
 - Removes the dialogs that used to appear on each new setup.
 
 
-[Unreleased]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0-rc.4...HEAD
+[Unreleased]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0...HEAD
+[1.6.0]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0-rc.4...v1.6.0
 [1.6.0-rc.4]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0-rc.3...v1.6.0-rc.4
 [1.6.0-rc.3]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0-rc.2...v1.6.0-rc.3
 [1.6.0-rc.2]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0-rc.1...v1.6.0-rc.2

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -92,8 +92,8 @@ val buildTimeProvider = providers.provider {
   df.format(Date())
 }
 
-val appVersionName = "1.6.0-rc.4"
-val appVersionCode = 129
+val appVersionName = "1.6.0"
+val appVersionCode = 130
 val minSDKVersion = 23
 val compileSDKVersion = 36
 

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <changelog>
   <version
-    version="Unreleased"
-    release="">
+    version="1.6.0"
+    release="Jun 1, 2026">
     <feature>Restores the sync action on the library top app bar, so a sync can be triggered without going through the empty-state button or settings.</feature>
     <feature>Adds a visible delete button on each connection row in the connection manager, with a confirmation dialog. Swipe-to-delete still works for power users.</feature>
     <feature>Network discovery now finds every MusicBee plugin on the LAN in a single scan, with re-broadcasts to combat multicast packet loss.</feature>


### PR DESCRIPTION
## Summary
Promotes the app to the final **1.6.0** release.

- `versionName` `1.6.0-rc.4` → **`1.6.0`**
- `versionCode` `129` → **`130`**
- `CHANGELOG.md`: `## [Unreleased]` → `## [1.6.0] - 2026-06-01`; repointed `[Unreleased]` to `v1.6.0...HEAD` and added the `[1.6.0]` (v1.6.0-rc.4...v1.6.0) comparison link
- `changelog.xml`: `Unreleased` version block → `version="1.6.0"`, `release="Jun 1, 2026"`

No code changes — release metadata only. Changelog content carried over from the rc cycle, including the marquee title scrolling feature.

## Next steps (after merge)
- Tag `v1.6.0` to trigger the release workflow.