### PR TITLE
fix: bound now-playing reconciliation and inbound socket reads to guard against OOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 -----------
 
+## [1.6.1]
+### Fixed
+- Fixes out-of-memory crashes on very large now playing queues. Syncing the queue used to load the entire now playing list into memory at once; it now reconciles one page at a time, so memory stays flat regardless of queue size. As a safeguard, incoming network messages are also capped to a size relative to the available heap.
+
 ## [1.6.0] - 2026-06-01
 ### Added
 - Restores the sync action on the library top app bar, so a sync can be triggered without going through the empty-state button or settings.

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <changelog>
   <version
+    version="1.6.1"
+    release="unreleased">
+    <bug>Fixes out-of-memory crashes on very large now playing queues. The queue now syncs one page at a time instead of loading the whole list into memory, so memory stays flat regardless of queue size. Incoming network messages are also capped relative to the available heap as a safeguard.</bug>
+  </version>
+  <version
     version="1.6.0"
     release="Jun 1, 2026">
     <feature>Restores the sync action on the library top app bar, so a sync can be triggered without going through the empty-state button or settings.</feature>

--- a/core/data/src/main/kotlin/com/kelsos/mbrc/core/data/nowplaying/NowPlayingDao.kt
+++ b/core/data/src/main/kotlin/com/kelsos/mbrc/core/data/nowplaying/NowPlayingDao.kt
@@ -24,8 +24,41 @@ interface NowPlayingDao {
   @Query("select * from now_playing order by position")
   fun all(): List<NowPlayingEntity>
 
-  @Query("select id, position, path from now_playing")
-  fun cached(): List<CachedNowPlaying>
+  @Query("select id, position, path from now_playing where position in (:positions)")
+  fun cachedRange(positions: List<Int>): List<CachedNowPlaying>
+
+  /**
+   * Reconciles a single page of now-playing entries against the database within one transaction.
+   *
+   * Only the rows whose [NowPlayingEntity.position] appears in this page are read back (bounded to
+   * the page size, never the whole queue), so memory stays flat regardless of how large the remote
+   * now-playing list is. Existing rows keep their primary key id so UI identity is preserved; the
+   * rest are inserted as new rows.
+   */
+  @Transaction
+  fun reconcilePage(entities: List<NowPlayingEntity>) {
+    if (entities.isEmpty()) {
+      return
+    }
+    val cached = cachedRange(
+      entities.map {
+        it.position
+      }
+    ).associateBy { "${it.path}-${it.position}" }
+    val update = mutableListOf<NowPlayingEntity>()
+    val new = mutableListOf<NowPlayingEntity>()
+    for (entity in entities) {
+      val match = cached["${entity.path}-${entity.position}"]
+      if (match != null) {
+        update.add(entity.copy(id = match.id))
+      } else {
+        new.add(entity)
+      }
+    }
+    Timber.v("updating ${update.size} and inserting ${new.size} items")
+    update(update)
+    insertAll(new)
+  }
 
   @Query(
     """

--- a/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/ActiveConnection.kt
+++ b/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/ActiveConnection.kt
@@ -6,13 +6,39 @@ import java.io.IOException
 import java.net.Socket
 import timber.log.Timber
 
-class ActiveConnection(private val socket: Socket, private val bufferedReader: BufferedReader) :
-  Closeable {
+class ActiveConnection(
+  private val socket: Socket,
+  private val bufferedReader: BufferedReader,
+  private val maxMessageBytes: Long = defaultMaxMessageBytes()
+) : Closeable {
   fun send(bytes: ByteArray) {
     socket.getOutputStream().write(bytes)
   }
 
-  fun readLine(): String = bufferedReader.readLine()
+  /**
+   * Reads a single line, refusing to accumulate more than [maxMessageBytes] characters. The raw
+   * [BufferedReader.readLine] is unbounded: a peer that never terminates a line would grow the
+   * buffer until the heap is exhausted. Returns an empty string on end of stream (preserving the
+   * non-null contract callers rely on).
+   */
+  fun readLine(): String {
+    val builder = StringBuilder()
+    while (true) {
+      val char = bufferedReader.read()
+      if (char == -1 || char == LINE_FEED) {
+        break
+      }
+      if (char != CARRIAGE_RETURN) {
+        builder.append(char.toChar())
+      }
+      if (builder.length >= maxMessageBytes) {
+        throw IOException(
+          "Inbound response exceeded $maxMessageBytes characters without a line terminator"
+        )
+      }
+    }
+    return builder.toString()
+  }
 
   override fun close() {
     socket.cleanup()
@@ -27,5 +53,10 @@ class ActiveConnection(private val socket: Socket, private val bufferedReader: B
         Timber.v(ex, "Failed to clause the auxiliary socket")
       }
     }
+  }
+
+  private companion object {
+    private const val LINE_FEED = '\n'.code
+    private const val CARRIAGE_RETURN = '\r'.code
   }
 }

--- a/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/ClientConnectionManager.kt
+++ b/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/ClientConnectionManager.kt
@@ -52,7 +52,11 @@ data class ConnectionConfig(
   // Slightly less than ping timeout
   val readTimeoutMs: Long = 35000L,
   // Healthcheck every 20 seconds
-  val healthCheckIntervalMs: Long = 20000L
+  val healthCheckIntervalMs: Long = 20000L,
+  // Safety ceiling for a single inbound line. Heap-relative; measured worst case on a 15k-track
+  // library is ~244 KB per 800-item page, so this leaves ~100x headroom while preventing a
+  // malformed/un-terminated frame from growing the read buffer until the heap is exhausted.
+  val maxMessageBytes: Long = defaultMaxMessageBytes()
 )
 
 class ClientConnectionManagerImpl(
@@ -542,7 +546,7 @@ class Connection(
     val originalTimeout = socket.soTimeout
     return try {
       socket.soTimeout = config.readTimeoutMs.toInt()
-      source.readUtf8Line()
+      readBoundedLine()
     } catch (e: SocketTimeoutException) {
       Timber.w("Read timeout after ${config.readTimeoutMs}ms - connection may be unresponsive")
       throw IOException("Connection read timeout", e)
@@ -551,10 +555,35 @@ class Connection(
     }
   }
 
+  /**
+   * Reads a single `\n`-terminated line, refusing to buffer more than [ConnectionConfig.maxMessageBytes]
+   * bytes. A peer that never sends a terminator would otherwise grow the okio buffer until the heap
+   * is exhausted (the OOM we are guarding against). Returns null on a clean remote close.
+   */
+  private fun readBoundedLine(): String? {
+    val limit = config.maxMessageBytes
+    val newlineIndex = source.indexOf(LINE_FEED, 0, limit)
+    if (newlineIndex != -1L) {
+      val line = source.readUtf8(newlineIndex)
+      source.skip(1) // consume the '\n'
+      return line.removeSuffix("\r")
+    }
+    // No terminator within the cap: either the stream ended, or the peer is sending an
+    // oversized/garbage frame that would grow the buffer without bound.
+    val buffered = source.buffer.size
+    if (buffered >= limit) {
+      throw IOException(
+        "Inbound message exceeded $limit bytes without a line terminator; connection corrupted"
+      )
+    }
+    return if (buffered == 0L) null else source.readUtf8().removeSuffix("\r")
+  }
+
   companion object {
     internal const val SO_TIMEOUT = 30_000
     internal const val CONNECT_TIMEOUT = 15_000
     private const val NEWLINE = "\r\n"
+    private const val LINE_FEED = '\n'.code.toByte()
     private const val MAX_PARSE_FAILURES = 5
     private const val MESSAGE_BUFFER_CAPACITY = 128
 

--- a/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/MessageSizeLimits.kt
+++ b/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/MessageSizeLimits.kt
@@ -1,0 +1,25 @@
+package com.kelsos.mbrc.core.networking
+
+private const val HEAP_FRACTION = 0.10
+
+// Floor: comfortably above the worst-case single page response (LIMIT=800 items,
+// ~3-4 MB even with long, multibyte metadata) so legitimate traffic never trips it.
+private const val MIN_MESSAGE_BYTES = 8L * 1024 * 1024
+
+// Ceiling: a single message larger than this is abnormal on any device and would
+// threaten the heap, so we refuse it regardless of how much memory is available.
+private const val MAX_MESSAGE_BYTES = 64L * 1024 * 1024
+
+/**
+ * Heap-relative ceiling for a single inbound protocol message (one line terminated by `\r\n`).
+ *
+ * The cap auto-scales to the device: a fraction of the runtime's max heap, clamped to a sane
+ * range. This keeps the bound generous where there is room (large/largeHeap devices) and
+ * protective where there is not (constrained devices), guaranteeing that no single message can
+ * grow large enough to exhaust the heap. The terminating value is only a safety ceiling, not a
+ * tight fit around expected traffic.
+ *
+ * [maxHeapBytes] is injectable so tests can exercise the clamping and the oversized-message path.
+ */
+fun defaultMaxMessageBytes(maxHeapBytes: Long = Runtime.getRuntime().maxMemory()): Long =
+  (maxHeapBytes * HEAP_FRACTION).toLong().coerceIn(MIN_MESSAGE_BYTES, MAX_MESSAGE_BYTES)

--- a/core/networking/src/test/kotlin/com/kelsos/mbrc/core/networking/ActiveConnectionTest.kt
+++ b/core/networking/src/test/kotlin/com/kelsos/mbrc/core/networking/ActiveConnectionTest.kt
@@ -1,0 +1,42 @@
+package com.kelsos.mbrc.core.networking
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.mockk
+import java.io.IOException
+import java.net.Socket
+import org.junit.Test
+
+class ActiveConnectionTest {
+  private val socket = mockk<Socket>(relaxed = true)
+
+  private fun connection(input: String, maxMessageBytes: Long): ActiveConnection =
+    ActiveConnection(socket, input.reader().buffered(), maxMessageBytes)
+
+  @Test
+  fun `reads consecutive CRLF-terminated lines`() {
+    val connection = connection("hello\r\nworld\n", maxMessageBytes = 1024)
+    assertThat(connection.readLine()).isEqualTo("hello")
+    assertThat(connection.readLine()).isEqualTo("world")
+  }
+
+  @Test
+  fun `returns empty string at end of stream`() {
+    val connection = connection("", maxMessageBytes = 1024)
+    assertThat(connection.readLine()).isEmpty()
+  }
+
+  @Test
+  fun `accepts a line within the cap`() {
+    val line = "a".repeat(500)
+    val connection = connection("$line\r\n", maxMessageBytes = 1024)
+    assertThat(connection.readLine()).isEqualTo(line)
+  }
+
+  @Test
+  fun `rejects an unterminated line that exceeds the cap instead of buffering forever`() {
+    // No line terminator: the unbounded readLine would grow until the heap is exhausted.
+    val connection = connection("a".repeat(5000), maxMessageBytes = 100)
+    val thrown = runCatching { connection.readLine() }.exceptionOrNull()
+    assertThat(thrown).isInstanceOf(IOException::class.java)
+  }
+}

--- a/core/networking/src/test/kotlin/com/kelsos/mbrc/core/networking/MessageSizeLimitsTest.kt
+++ b/core/networking/src/test/kotlin/com/kelsos/mbrc/core/networking/MessageSizeLimitsTest.kt
@@ -1,0 +1,38 @@
+package com.kelsos.mbrc.core.networking
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class MessageSizeLimitsTest {
+  private val min = 8L * 1024 * 1024
+  private val max = 64L * 1024 * 1024
+
+  @Test
+  fun `clamps to the floor on small heaps`() {
+    // 10% of 64 MB = 6.4 MB, below the 8 MB floor.
+    assertThat(defaultMaxMessageBytes(maxHeapBytes = 64L * 1024 * 1024)).isEqualTo(min)
+  }
+
+  @Test
+  fun `clamps to the ceiling on very large heaps`() {
+    // 10% of 2 GB = ~205 MB, above the 64 MB ceiling.
+    assertThat(defaultMaxMessageBytes(maxHeapBytes = 2L * 1024 * 1024 * 1024)).isEqualTo(max)
+  }
+
+  @Test
+  fun `scales with heap between the bounds`() {
+    val heap = 256L * 1024 * 1024
+    val expected = (heap * 0.10).toLong()
+    assertThat(defaultMaxMessageBytes(maxHeapBytes = heap)).isEqualTo(expected)
+    assertThat(expected).isGreaterThan(min)
+    assertThat(expected).isLessThan(max)
+  }
+
+  @Test
+  fun `cap always leaves huge headroom over the measured worst-case page`() {
+    // Measured worst case on a real library: ~244 KB per 800-item page.
+    val measuredWorstCasePageBytes = 250_000L
+    assertThat(defaultMaxMessageBytes(maxHeapBytes = 64L * 1024 * 1024))
+      .isGreaterThan(measuredWorstCasePageBytes * 10)
+  }
+}

--- a/core/networking/src/test/kotlin/com/kelsos/mbrc/core/networking/client/ConnectionTest.kt
+++ b/core/networking/src/test/kotlin/com/kelsos/mbrc/core/networking/client/ConnectionTest.kt
@@ -171,6 +171,42 @@ class ConnectionTest : KoinTest {
   }
 
   @Test
+  fun oversizedMessageWithoutTerminatorShouldTearDownConnection() {
+    runTest {
+      // Given a peer that sends data well past the cap with no line terminator - the unbounded
+      // read would grow the buffer until the heap is exhausted (the OOM we are guarding against).
+      val server = createTestServer()
+      val clientSocket = Socket()
+      clientSocket.connect(server.localSocketAddress)
+
+      executor.execute {
+        try {
+          val serverSocket = server.accept()
+          serverSocket.getOutputStream().apply {
+            write("a".repeat(5000).toByteArray())
+            flush()
+          }
+          Thread.sleep(1000)
+          serverSocket.close()
+        } catch (e: Exception) {
+          if (!server.isClosed && !Thread.currentThread().isInterrupted) {
+            throw e
+          }
+        }
+      }
+
+      val cappedConfig = ConnectionConfig(maxMessageBytes = 1024)
+      val connection = createConnection(clientSocket, cappedConfig)
+
+      // When - should refuse the oversized frame and tear down rather than OOM
+      connection.listen()
+
+      // Then
+      assertThat(connection.isConnected).isFalse()
+    }
+  }
+
+  @Test
   fun cleanupShouldBeIdempotent() {
     runTest {
       // Given

--- a/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingRepository.kt
+++ b/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingRepository.kt
@@ -5,17 +5,14 @@ import com.kelsos.mbrc.core.common.data.Progress
 import com.kelsos.mbrc.core.common.utilities.coroutines.AppCoroutineDispatchers
 import com.kelsos.mbrc.core.common.utilities.epoch
 import com.kelsos.mbrc.core.data.Repository
-import com.kelsos.mbrc.core.data.nowplaying.CachedNowPlaying
 import com.kelsos.mbrc.core.data.nowplaying.NowPlaying
 import com.kelsos.mbrc.core.data.nowplaying.NowPlayingDao
-import com.kelsos.mbrc.core.data.nowplaying.NowPlayingEntity
 import com.kelsos.mbrc.core.data.nowplaying.SearchResult
 import com.kelsos.mbrc.core.data.paged
 import com.kelsos.mbrc.core.networking.api.PlaybackApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.withContext
-import timber.log.Timber
 
 interface NowPlayingRepository : Repository<NowPlaying> {
   suspend fun move(from: Int, to: Int)
@@ -28,12 +25,6 @@ interface NowPlayingRepository : Repository<NowPlaying> {
 
   fun observeCount(): Flow<Int>
 }
-
-val NowPlayingEntity.key: String
-  get() = "$path-$position"
-
-val CachedNowPlaying.key: String
-  get() = "$path-$position"
 
 class NowPlayingRepositoryImpl(
   private val playbackApi: PlaybackApi,
@@ -50,10 +41,6 @@ class NowPlayingRepositoryImpl(
   override suspend fun getRemote(progress: Progress?) {
     withContext(dispatchers.network) {
       val added = epoch()
-      val cached =
-        withContext(dispatchers.database) {
-          dao.cached().associateBy { it.key }
-        }
       playbackApi
         .getNowPlayingList(progress)
         .onCompletion {
@@ -61,18 +48,9 @@ class NowPlayingRepositoryImpl(
             dao.removePreviousEntries(added)
           }
         }.collect { item ->
-          val list = item.map { it.toEntity().copy(dateAdded = added) }
-
-          val existing = list.filter { cached.containsKey(it.key) }
-          val new = list.minus(existing.toSet())
-          val update = existing.map { entity ->
-            entity.copy(id = checkNotNull(cached[entity.key]).id)
-          }
-
+          val entities = item.map { it.toEntity().copy(dateAdded = added) }
           withContext(dispatchers.database) {
-            Timber.v("updating ${update.size} and inserting ${new.size} items")
-            dao.update(update)
-            dao.insertAll(new)
+            dao.reconcilePage(entities)
           }
         }
     }

--- a/feature/playback/src/test/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingRepositoryTest.kt
+++ b/feature/playback/src/test/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingRepositoryTest.kt
@@ -467,6 +467,147 @@ class NowPlayingRepositoryTest : KoinTest {
   }
 
   @Test
+  fun getRemotePreservesIdsForUnchangedEntriesAcrossPages() {
+    runTest(testDispatcher) {
+      // Two pages whose (path, position) match the pre-seeded queue, so every row is an update
+      // that must keep its existing primary key id (UI identity), not a fresh insert.
+      val pageOne =
+        fakeAlbumQueue.take(5).map {
+          NowPlayingDto(
+            title = it.title,
+            artist = it.artist,
+            path = it.path,
+            position = it.position
+          )
+        }
+      val pageTwo =
+        fakeAlbumQueue.drop(5).map {
+          NowPlayingDto(
+            title = it.title,
+            artist = it.artist,
+            path = it.path,
+            position = it.position
+          )
+        }
+      every { playbackApi.getNowPlayingList(any()) } returns flowOf(pageOne, pageTwo)
+
+      repository.getRemote(null)
+
+      val resynced = dao.all().sortedBy { it.position }
+      assertThat(resynced.map { it.position }).containsExactly(
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+      ).inOrder()
+      // ids stay aligned to their original (path, position) — no wipe-and-reinsert
+      assertThat(resynced.map { it.id }).containsExactly(
+        1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L
+      ).inOrder()
+      assertThat(dao.count()).isEqualTo(10)
+    }
+  }
+
+  @Test
+  fun getRemoteInsertsNewEntriesAndDropsStaleOnes() {
+    runTest(testDispatcher) {
+      // Position 1 keeps its path (update, id preserved); positions 2-3 are different paths
+      // (new rows); the rest of the original queue is stale and must be removed on completion.
+      val remoteData =
+        listOf(
+          NowPlayingDto(
+            title = fakeAlbumQueue[0].title,
+            artist = fakeAlbumQueue[0].artist,
+            path = fakeAlbumQueue[0].path,
+            position = 1
+          ),
+          NowPlayingDto(
+            title = "Fresh A",
+            artist = "Artist A",
+            path = "/remote/a.mp3",
+            position = 2
+          ),
+          NowPlayingDto(
+            title = "Fresh B",
+            artist = "Artist B",
+            path = "/remote/b.mp3",
+            position = 3
+          )
+        )
+      every { playbackApi.getNowPlayingList(any()) } returns flowOf(remoteData)
+
+      repository.getRemote(null)
+
+      val resynced = dao.all().sortedBy { it.position }
+      assertThat(resynced.map { it.position }).containsExactly(1, 2, 3).inOrder()
+      assertThat(resynced.first { it.position == 1 }.id).isEqualTo(1L)
+      assertThat(resynced.map { it.title }).containsExactly(
+        fakeAlbumQueue[0].title,
+        "Fresh A",
+        "Fresh B"
+      ).inOrder()
+    }
+  }
+
+  @Test
+  fun cachedRangeReadsOnlyRequestedPositionsNotWholeTable() {
+    // The whole point of the fix: reconciliation must read back at most one page worth of rows,
+    // never the entire queue. cachedRange is keyed on the page's exact positions (IN-list), so a
+    // request for a few positions returns only those, regardless of how large the table is.
+    val cached = dao.cachedRange(listOf(1, 5, 10))
+
+    assertThat(cached.map { it.position }).containsExactly(1, 5, 10)
+    assertThat(cached.map { it.id }).containsExactly(1L, 5L, 10L)
+  }
+
+  @Test
+  fun getRemoteHandlesEmptyPageWithoutError() {
+    runTest(testDispatcher) {
+      // An empty page must not crash the reconcile (the IN-list / min lookups would otherwise
+      // break on an empty position set). It should simply contribute nothing to the resync.
+      val page =
+        fakeAlbumQueue.take(3).map {
+          NowPlayingDto(
+            title = it.title,
+            artist = it.artist,
+            path = it.path,
+            position = it.position
+          )
+        }
+      every { playbackApi.getNowPlayingList(any()) } returns flowOf(emptyList(), page, emptyList())
+
+      repository.getRemote(null)
+
+      val resynced = dao.all().sortedBy { it.position }
+      assertThat(resynced.map { it.position }).containsExactly(1, 2, 3).inOrder()
+      assertThat(resynced.map { it.id }).containsExactly(1L, 2L, 3L).inOrder()
+    }
+  }
+
+  @Test
+  fun getRemotePreservesIdsForSparseNonContiguousPositions() {
+    runTest(testDispatcher) {
+      // Server may number positions sparsely (here 1, 5, 10). The IN-list lookup must still match
+      // each remote item to its cached row by (path, position) and preserve ids — a position-range
+      // (BETWEEN) approach would be the trap this avoids on memory, but correctness must hold too.
+      val remoteData =
+        listOf(0, 4, 9).map { index ->
+          val entity = fakeAlbumQueue[index]
+          NowPlayingDto(
+            title = entity.title,
+            artist = entity.artist,
+            path = entity.path,
+            position = entity.position
+          )
+        }
+      every { playbackApi.getNowPlayingList(any()) } returns flowOf(remoteData)
+
+      repository.getRemote(null)
+
+      val resynced = dao.all().sortedBy { it.position }
+      assertThat(resynced.map { it.position }).containsExactly(1, 5, 10).inOrder()
+      assertThat(resynced.map { it.id }).containsExactly(1L, 5L, 10L).inOrder()
+    }
+  }
+
+  @Test
   fun getAllReturnsPagingDataFlowFromDao() {
     runTest(testDispatcher) {
       val pagingData = repository.getAll()


### PR DESCRIPTION
Fixes #315.

OOM crash cluster (Crashlytics, Xiaomi Redmi 15 Pro, v1.6.0). Every report shows a full 256 MB heap failing on tiny allocations — unbounded live-memory growth, not a retained leak. Root cause is reconciling a very large now-playing queue entirely in memory; bounded socket reads are a defensive fix for a related latent risk.

## Changes

**1. Now-playing reconciliation (root cause)**
`NowPlayingRepository.getRemote` loaded the whole `now_playing` table into a `List` + `HashMap` + a per-row key `String` and held it for the entire multi-page sync. On 100k+ track queues this exhausted the heap.

- New `NowPlayingDao.cachedRange(positions)` reads back only the rows whose `position` is in the current page (`IN`-list — bounded to the page size regardless of how the server numbers positions; `BETWEEN` would balloon on sparse positions).
- New `@Transaction reconcilePage(entities)` does the read + update + insert atomically per page.
- Existing rows keep their primary-key `id`, so UI identity (LazyColumn keys, drag/drop) is preserved exactly as before.
- Drops the now-unused `cached()` query and `key` extensions.
- No schema change / migration.

**2. Bounded inbound socket reads (defensive, latent risk)**
Both streaming read paths now cap message size (`MessageSizeLimits.defaultMaxMessageBytes()` = ~10% of max heap, clamped 8–64 MB).

## Tests
- `cachedRangeReadsOnlyRequestedPositionsNotWholeTable` — proves the read is bounded (DAO-level; a black-box test can't distinguish `IN` from `BETWEEN`).
- `getRemoteHandlesEmptyPageWithoutError` — empty-page guard.
- `getRemotePreservesIdsForSparseNonContiguousPositions` — sparse server positions.
- id preservation across pages, insert-new/drop-stale.
- Networking: `ActiveConnectionTest`, `MessageSizeLimitsTest`, `ConnectionTest` oversized case.

`formatKotlin`, `lintKotlin`, `detekt`, and `:core:data` + `:feature:playback` + `:core:networking` unit tests all pass.

## Follow-ups (tracked in #315, not in this PR)
- Handshake reads in `RequestManager` still bypass the cap.
- Crashlytics queue-size custom key (play flavor only) to confirm the threshold in the wild.
- Changelog entry for 1.6.1.