### PR TITLE
fix(nowplaying): single-flight refresh + handle libraryplayall broadcast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 ## [1.6.1]
 ### Fixed
 - Fixes out-of-memory crashes on very large now playing queues. Syncing the queue used to load the entire now playing list into memory at once; it now reconciles one page at a time, so memory stays flat regardless of queue size. As a safeguard, incoming network messages are also capped to a size relative to the available heap.
+- Fixes the now playing queue sometimes loading only part of the list. Refreshes triggered close together (opening the screen, pull-to-refresh, or a server-side queue change) could overlap and overwrite each other's writes; a newer refresh now cancels and restarts the in-flight one, so the full queue is always loaded. A failed or superseded refresh no longer clears the existing queue.
+- Fixes a spurious error being logged on every "play all" action. The play-all confirmation broadcast from the plugin is now handled instead of being treated as an unsupported message.
 
 ## [1.6.0] - 2026-06-01
 ### Added

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -4,6 +4,8 @@
     version="1.6.1"
     release="unreleased">
     <bug>Fixes out-of-memory crashes on very large now playing queues. The queue now syncs one page at a time instead of loading the whole list into memory, so memory stays flat regardless of queue size. Incoming network messages are also capped relative to the available heap as a safeguard.</bug>
+    <bug>Fixes the now playing queue sometimes loading only part of the list. Refreshes triggered close together no longer overlap and overwrite each other; a newer refresh cancels and restarts the in-flight one, so the full queue is always loaded.</bug>
+    <bug>Fixes a spurious error logged on every "play all" action by handling the play-all confirmation broadcast instead of treating it as an unsupported message.</bug>
   </version>
   <version
     version="1.6.0"

--- a/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/protocol/usecases/CommandFactory.kt
+++ b/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/protocol/usecases/CommandFactory.kt
@@ -62,6 +62,7 @@ class CommandFactoryImpl(private val resolver: (KClass<out ProtocolAction>) -> P
       Protocol.PlayerPlayPause to SimpleLogCommand::class,
       Protocol.NowPlayingListPlay to SimpleLogCommand::class,
       Protocol.PlaylistPlay to SimpleLogCommand::class,
+      Protocol.LibraryPlayAll to SimpleLogCommand::class,
       Protocol.ProtocolTag to ProtocolVersionUpdate::class
     )
 

--- a/core/networking/src/test/kotlin/com/kelsos/mbrc/core/networking/protocol/usecases/CommandFactoryTest.kt
+++ b/core/networking/src/test/kotlin/com/kelsos/mbrc/core/networking/protocol/usecases/CommandFactoryTest.kt
@@ -239,6 +239,13 @@ class CommandFactoryTest {
     assertThat(action).isNotNull()
   }
 
+  @Test
+  fun `create should return SimpleLogCommand for LibraryPlayAll protocol`() {
+    val action = commandFactory.create(Protocol.LibraryPlayAll)
+    assertThat(createdActions.keys).contains(SimpleLogCommand::class)
+    assertThat(action).isNotNull()
+  }
+
   // endregion
 
   // region Error handling

--- a/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingRepository.kt
+++ b/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingRepository.kt
@@ -10,8 +10,14 @@ import com.kelsos.mbrc.core.data.nowplaying.NowPlayingDao
 import com.kelsos.mbrc.core.data.nowplaying.SearchResult
 import com.kelsos.mbrc.core.data.paged
 import com.kelsos.mbrc.core.networking.api.PlaybackApi
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 interface NowPlayingRepository : Repository<NowPlaying> {
@@ -31,6 +37,12 @@ class NowPlayingRepositoryImpl(
   private val dao: NowPlayingDao,
   private val dispatchers: AppCoroutineDispatchers
 ) : NowPlayingRepository {
+  // App-lifetime scope owning the single in-flight refresh. SupervisorJob keeps one refresh's
+  // failure from cancelling the scope or a later refresh.
+  private val refreshScope = CoroutineScope(dispatchers.network + SupervisorJob())
+  private val refreshMutex = Mutex()
+  private var refreshJob: Deferred<Unit>? = null
+
   override suspend fun count(): Long = withContext(dispatchers.database) { dao.count() }
 
   override fun getAll(): Flow<PagingData<NowPlaying>> = paged(
@@ -38,22 +50,40 @@ class NowPlayingRepositoryImpl(
     enablePlaceholders = true
   ) { it.toNowPlaying() }
 
+  /**
+   * Refreshes the now-playing queue, keeping only a single refresh in flight. A newer trigger
+   * (user pull-to-refresh or a `nowplayinglistchanged` broadcast) cancels any refresh already
+   * running and restarts from the first page, so two refreshes never interleave their writes —
+   * which previously let one refresh's `removePreviousEntries` delete the other's rows and leave
+   * a truncated queue. The caller still suspends until its own refresh finishes (or fails).
+   */
   override suspend fun getRemote(progress: Progress?) {
-    withContext(dispatchers.network) {
-      val added = epoch()
-      playbackApi
-        .getNowPlayingList(progress)
-        .onCompletion {
+    val job =
+      refreshMutex.withLock {
+        refreshJob?.cancel()
+        refreshScope.async { fetchAndReconcile(progress) }.also { refreshJob = it }
+      }
+    job.await()
+  }
+
+  private suspend fun fetchAndReconcile(progress: Progress?) {
+    val added = epoch()
+    playbackApi
+      .getNowPlayingList(progress)
+      .onCompletion { cause ->
+        // Only prune stale rows after a clean run. A cancelled (superseded) or failed refresh
+        // must leave the existing queue intact — the replacing/next successful refresh prunes.
+        if (cause == null) {
           withContext(dispatchers.database) {
             dao.removePreviousEntries(added)
           }
-        }.collect { item ->
-          val entities = item.map { it.toEntity().copy(dateAdded = added) }
-          withContext(dispatchers.database) {
-            dao.reconcilePage(entities)
-          }
         }
-    }
+      }.collect { item ->
+        val entities = item.map { it.toEntity().copy(dateAdded = added) }
+        withContext(dispatchers.database) {
+          dao.reconcilePage(entities)
+        }
+      }
   }
 
   override fun search(term: String): Flow<PagingData<NowPlaying>> = paged({

--- a/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingUiMessages.kt
+++ b/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingUiMessages.kt
@@ -7,6 +7,9 @@ sealed class NowPlayingUiMessages : UiMessageBase {
 
   data object RefreshSucceeded : NowPlayingUiMessages()
 
+  /** A newer refresh took over before this one finished; dismiss the indicator without a result. */
+  data object RefreshSuperseded : NowPlayingUiMessages()
+
   data object NetworkUnavailable : NowPlayingUiMessages()
 
   data object PlayFailed : NowPlayingUiMessages()

--- a/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingViewModel.kt
+++ b/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingViewModel.kt
@@ -15,12 +15,14 @@ import com.kelsos.mbrc.core.networking.protocol.usecases.moveTrack
 import com.kelsos.mbrc.core.networking.protocol.usecases.playTrack
 import com.kelsos.mbrc.core.networking.protocol.usecases.removeTrack
 import java.io.IOException
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -66,6 +68,12 @@ class NowPlayingActions(
         try {
           repository.getRemote()
           if (showUserMessage) NowPlayingUiMessages.RefreshSucceeded else null
+        } catch (e: CancellationException) {
+          // A newer refresh superseded this one. If this coroutine is still active the shared
+          // refresh was cancelled (not our scope), so just dismiss the indicator; otherwise our
+          // scope is going away (e.g. screen closed) and the cancellation must propagate.
+          if (!isActive) throw e
+          if (showUserMessage) NowPlayingUiMessages.RefreshSuperseded else null
         } catch (e: IOException) {
           Timber.e(e)
           if (showUserMessage) NowPlayingUiMessages.RefreshFailed(e) else null

--- a/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/compose/NowPlayingScreen.kt
+++ b/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/compose/NowPlayingScreen.kt
@@ -220,6 +220,10 @@ private fun NowPlayingEventsEffect(
           onRefreshComplete()
         }
 
+        NowPlayingUiMessages.RefreshSuperseded -> {
+          onRefreshComplete()
+        }
+
         NowPlayingUiMessages.NetworkUnavailable -> {
           onRefreshComplete()
           snackbarHostState.showSnackbar(networkUnavailableMessage)

--- a/feature/playback/src/test/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingRepositoryTest.kt
+++ b/feature/playback/src/test/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingRepositoryTest.kt
@@ -14,7 +14,11 @@ import com.kelsos.mbrc.core.networking.api.PlaybackApi
 import com.kelsos.mbrc.core.networking.dto.NowPlayingDto
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
@@ -578,6 +582,41 @@ class NowPlayingRepositoryTest : KoinTest {
       val resynced = dao.all().sortedBy { it.position }
       assertThat(resynced.map { it.position }).containsExactly(1, 2, 3).inOrder()
       assertThat(resynced.map { it.id }).containsExactly(1L, 2L, 3L).inOrder()
+    }
+  }
+
+  @Test
+  fun getRemoteCancelsInflightRefreshWhenANewerOneStarts() {
+    runTest(testDispatcher) {
+      // First refresh blocks before emitting any page, simulating one still in flight.
+      val blocker = CompletableDeferred<Unit>()
+      val slowFlow =
+        flow {
+          blocker.await()
+          emit(emptyList<NowPlayingDto>())
+        }
+      // Second (newer) refresh carries a different queue and completes normally.
+      val newQueue =
+        listOf(
+          NowPlayingDto(title = "B1", artist = "Artist B", path = "/remote/b1.mp3", position = 1),
+          NowPlayingDto(title = "B2", artist = "Artist B", path = "/remote/b2.mp3", position = 2)
+        )
+      every { playbackApi.getNowPlayingList(any()) } returnsMany
+        listOf(slowFlow, flowOf(newQueue))
+
+      dao.deleteAll()
+
+      // Start the slow refresh; it parks on the blocker and never finishes on its own.
+      val inflight = launch { repository.getRemote(null) }
+      advanceUntilIdle()
+
+      // A newer trigger must cancel the in-flight one and restart from scratch.
+      repository.getRemote(null)
+
+      assertThat(inflight.isCancelled).isTrue()
+      val resynced = dao.all().sortedBy { it.position }
+      assertThat(resynced.map { it.title }).containsExactly("B1", "B2").inOrder()
+      assertThat(dao.count()).isEqualTo(2)
     }
   }
 

--- a/feature/playback/src/test/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingViewModelTest.kt
+++ b/feature/playback/src/test/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingViewModelTest.kt
@@ -22,6 +22,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import java.io.IOException
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -174,6 +175,27 @@ class NowPlayingViewModelTest : KoinTest {
 
       // Verify repository was called (once from init, once from test)
       coVerify(exactly = 2) { repository.getRemote() }
+    }
+  }
+
+  @Test
+  fun reloadShouldEmitRefreshSupersededWhenRefreshIsCancelledByANewerOne() {
+    runTest(testDispatcher) {
+      // Given — the shared single-flight refresh in the repository is cancelled because a newer
+      // trigger (broadcast or another pull) superseded it; getRemote surfaces a CancellationException
+      // while this view-model coroutine itself stays active.
+      coEvery { connectionStateFlow.isConnected } returns true
+      coEvery { repository.getRemote() } throws
+        CancellationException("superseded by a newer refresh")
+
+      // When & Then — must end the pull-to-refresh indicator without reporting success or failure.
+      viewModel.events.test {
+        viewModel.actions.reload(showUserMessage = true)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val event = awaitItem()
+        assertThat(event).isEqualTo(NowPlayingUiMessages.RefreshSuperseded)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Two now-playing reliability fixes, staged under the existing **1.6.1** changelog entry (alongside the OOM fix from #316).

### 1. Single-flight now-playing refresh (`467cfe19`)
Refreshes triggered close together — opening the screen, pull-to-refresh, or a server-side queue change — could overlap and overwrite each other's writes, leaving the queue with only part of the list loaded. A newer refresh now **cancels and restarts** the in-flight one, so the full queue is always loaded.

Additional hardening:
- A failed or superseded refresh no longer clears the existing queue (prune-on-clean only).
- Pull-to-refresh respects supersession so a later trigger wins.

### 2. Handle `libraryplayall` broadcast (`7f406caa`)
The play-all confirmation broadcast from the plugin was treated as an unsupported message, logging a spurious error on every "play all" action. It's now handled explicitly.

## Testing
- Unit tests added for both fixes (`NowPlayingRepositoryTest`, `NowPlayingViewModelTest`, `CommandFactoryTest`).
- All local checks green: tests, lint, detekt, ktlint.

## Notes
- No DB migration; no schema changes.
- Known follow-up (not in this PR): the ~6–7k partial-load case may also involve an early `break` in `ApiBase.getAllPages` on the server's `page.total`. To be verified on-device after this ships.
