### PR TITLE
fix(nowplaying): key reconciliation by position to prevent duplicate-key crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 - Fixes out-of-memory crashes on very large now playing queues. Syncing the queue used to load the entire now playing list into memory at once; it now reconciles one page at a time, so memory stays flat regardless of queue size. As a safeguard, incoming network messages are also capped to a size relative to the available heap.
 - Fixes the now playing queue sometimes loading only part of the list. Refreshes triggered close together (opening the screen, pull-to-refresh, or a server-side queue change) could overlap and overwrite each other's writes; a newer refresh now cancels and restarts the in-flight one, so the full queue is always loaded. A failed or superseded refresh no longer clears the existing queue.
 - Fixes a spurious error being logged on every "play all" action. The play-all confirmation broadcast from the plugin is now handled instead of being treated as an unsupported message.
+- Fixes a crash when scrolling the now playing queue during a refresh. Reconciling the queue could briefly leave two entries at the same position, which the list could then show twice and crash on; each position now updates in place, so an entry is never duplicated.
 
 ## [1.6.0] - 2026-06-01
 ### Added

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -6,6 +6,7 @@
     <bug>Fixes out-of-memory crashes on very large now playing queues. The queue now syncs one page at a time instead of loading the whole list into memory, so memory stays flat regardless of queue size. Incoming network messages are also capped relative to the available heap as a safeguard.</bug>
     <bug>Fixes the now playing queue sometimes loading only part of the list. Refreshes triggered close together no longer overlap and overwrite each other; a newer refresh cancels and restarts the in-flight one, so the full queue is always loaded.</bug>
     <bug>Fixes a spurious error logged on every "play all" action by handling the play-all confirmation broadcast instead of treating it as an unsupported message.</bug>
+    <bug>Fixes a crash when scrolling the now playing queue during a refresh. Reconciling the queue could briefly leave two entries at the same position; each position now updates in place, so an entry is never duplicated.</bug>
   </version>
   <version
     version="1.6.0"

--- a/core/data/src/main/kotlin/com/kelsos/mbrc/core/data/nowplaying/NowPlayingDao.kt
+++ b/core/data/src/main/kotlin/com/kelsos/mbrc/core/data/nowplaying/NowPlayingDao.kt
@@ -31,9 +31,13 @@ interface NowPlayingDao {
    * Reconciles a single page of now-playing entries against the database within one transaction.
    *
    * Only the rows whose [NowPlayingEntity.position] appears in this page are read back (bounded to
-   * the page size, never the whole queue), so memory stays flat regardless of how large the remote
-   * now-playing list is. Existing rows keep their primary key id so UI identity is preserved; the
-   * rest are inserted as new rows.
+   * the page size, never the whole queue), so memory stays flat regardless of queue size.
+   *
+   * Identity is keyed on [NowPlayingEntity.position]: an existing row at a position is updated in
+   * place (keeping its id, so UI identity stays stable), otherwise it is inserted. This keeps at
+   * most one row per position at all times — keying on `(path, position)` would instead leave the
+   * stale row in place until the end-of-refresh prune, briefly giving the `order by position`
+   * PagingSource two rows per position and crashing the LazyColumn with a duplicate key.
    */
   @Transaction
   fun reconcilePage(entities: List<NowPlayingEntity>) {
@@ -44,11 +48,11 @@ interface NowPlayingDao {
       entities.map {
         it.position
       }
-    ).associateBy { "${it.path}-${it.position}" }
+    ).associateBy { it.position }
     val update = mutableListOf<NowPlayingEntity>()
     val new = mutableListOf<NowPlayingEntity>()
     for (entity in entities) {
-      val match = cached["${entity.path}-${entity.position}"]
+      val match = cached[entity.position]
       if (match != null) {
         update.add(entity.copy(id = match.id))
       } else {

--- a/feature/playback/src/test/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingRepositoryTest.kt
+++ b/feature/playback/src/test/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingRepositoryTest.kt
@@ -621,6 +621,38 @@ class NowPlayingRepositoryTest : KoinTest {
   }
 
   @Test
+  fun reconcilePageReplacesTrackAtExistingPositionInPlaceWithoutLeavingDuplicate() {
+    // Regression for the duplicate-key crash: changing the track at an existing position must update
+    // that row in place (one row per position), not insert a second row alongside the stale one.
+    val replacement =
+      listOf(1, 2, 3).map { pos ->
+        NowPlayingEntity(
+          title = "Replacement $pos",
+          artist = "New Artist",
+          path = "/remote/replacement_$pos.mp3",
+          position = pos,
+          dateAdded = 999L
+        )
+      }
+
+    dao.reconcilePage(replacement)
+
+    // Exactly one row per affected position — no stale duplicates left behind by the page reconcile.
+    val rows = dao.all().sortedBy { it.position }
+    assertThat(rows.count { it.position == 1 }).isEqualTo(1)
+    assertThat(rows.count { it.position == 2 }).isEqualTo(1)
+    assertThat(rows.count { it.position == 3 }).isEqualTo(1)
+    // Slots 1-3 kept their original ids (updated in place), so UI identity is stable.
+    assertThat(rows.first { it.position == 1 }.id).isEqualTo(1L)
+    assertThat(rows.first { it.position == 2 }.id).isEqualTo(2L)
+    assertThat(rows.first { it.position == 3 }.id).isEqualTo(3L)
+    assertThat(rows.first { it.position == 1 }.title).isEqualTo("Replacement 1")
+    // Untouched positions (4-10) are still present; total is unchanged, not doubled.
+    assertThat(dao.count()).isEqualTo(10)
+    assertThat(rows.map { it.position }.toSet()).hasSize(10)
+  }
+
+  @Test
   fun getRemotePreservesIdsForSparseNonContiguousPositions() {
     runTest(testDispatcher) {
       // Server may number positions sparsely (here 1, 5, 10). The IN-list lookup must still match


### PR DESCRIPTION
## Summary

Fixes a `LazyColumn` crash on the now playing screen:

```
java.lang.IllegalArgumentException: Key "11851" was already used.
```

### Root cause
`NowPlayingDao.reconcilePage` matched cached rows by `(path, position)`. When a refresh changed the track occupying an existing position, the new track's `(path, position)` didn't match, so it was **inserted as a new row** — while the **stale row at that same position stayed in the table** until `removePreviousEntries` runs at the very end of the refresh (`onCompletion`).

For the duration of the refresh the table therefore held **two rows at the same `position`**. The PagingSource (`select * from now_playing order by position`) then has ties, and as the user scrolls — forcing `LIMIT/OFFSET` page reloads while the row count shifts — the same physical row gets returned in two different page windows. Two list slots end up with the same `id`, and Compose throws the duplicate-key error.

This is why it only reproduces while **scrolling during a refresh**, never during drag-sort (drag inserts no rows).

### Fix
Key reconciliation by **`position` only** and update the row in place (keeping its primary key id). This guarantees **at most one row per position at all times**, so the order-by-position paging never has ties. Per-slot UI/scroll identity is preserved, and the table no longer transiently doubles in size (a small memory win too).

## Testing
- New regression test `reconcilePageReplacesTrackAtExistingPositionInPlaceWithoutLeavingDuplicate` — replacing the track at an occupied position updates in place (one row per position), no stale duplicate.
- Full `./gradlew test` green across all modules.
- Verified on-device against a ~15.7k-track queue: scrolling during refresh / play-all no longer crashes.

## Notes
- No schema change, no migration.
- Staged under the existing **1.6.1** changelog entry.
- Independent of #317 (single-flight refresh); this is a separate, pre-existing fragility in the same reconcile path.
