### PR TITLE
feat(nowplaying): show sync progress bar while the queue refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog
 -----------
 
 ## [1.6.1]
+### Added
+- Shows a progress bar at the top of the now playing queue while it is syncing, so a long sync (opening the screen, pull-to-refresh, or a server-side "play all") gives visible feedback instead of appearing stalled. The bar reflects the actual page-load progress reported by the server.
+
 ### Fixed
 - Fixes out-of-memory crashes on very large now playing queues. Syncing the queue used to load the entire now playing list into memory at once; it now reconciles one page at a time, so memory stays flat regardless of queue size. As a safeguard, incoming network messages are also capped to a size relative to the available heap.
 - Fixes the now playing queue sometimes loading only part of the list. Refreshes triggered close together (opening the screen, pull-to-refresh, or a server-side queue change) could overlap and overwrite each other's writes; a newer refresh now cancels and restarts the in-flight one, so the full queue is always loaded. A failed or superseded refresh no longer clears the existing queue.

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -3,6 +3,7 @@
   <version
     version="1.6.1"
     release="unreleased">
+    <feature>Shows a progress bar at the top of the now playing queue while it syncs, so a long sync (opening the screen, pull-to-refresh, or a server-side "play all") gives visible feedback instead of appearing stalled.</feature>
     <bug>Fixes out-of-memory crashes on very large now playing queues. The queue now syncs one page at a time instead of loading the whole list into memory, so memory stays flat regardless of queue size. Incoming network messages are also capped relative to the available heap as a safeguard.</bug>
     <bug>Fixes the now playing queue sometimes loading only part of the list. Refreshes triggered close together no longer overlap and overwrite each other; a newer refresh cancels and restarts the in-flight one, so the full queue is always loaded.</bug>
     <bug>Fixes a spurious error logged on every "play all" action by handling the play-all confirmation broadcast instead of treating it as an unsupported message.</bug>

--- a/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingRepository.kt
+++ b/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingRepository.kt
@@ -10,11 +10,15 @@ import com.kelsos.mbrc.core.data.nowplaying.NowPlayingDao
 import com.kelsos.mbrc.core.data.nowplaying.SearchResult
 import com.kelsos.mbrc.core.data.paged
 import com.kelsos.mbrc.core.networking.api.PlaybackApi
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -30,6 +34,13 @@ interface NowPlayingRepository : Repository<NowPlaying> {
   suspend fun searchTrack(query: String): SearchResult?
 
   fun observeCount(): Flow<Int>
+
+  /**
+   * Progress of the single in-flight refresh, regardless of which trigger started it
+   * (screen reload, pull-to-refresh, or a `nowplayinglistchanged` broadcast). Emits `null`
+   * while idle.
+   */
+  fun syncProgress(): StateFlow<SyncProgress?>
 }
 
 class NowPlayingRepositoryImpl(
@@ -42,6 +53,10 @@ class NowPlayingRepositoryImpl(
   private val refreshScope = CoroutineScope(dispatchers.network + SupervisorJob())
   private val refreshMutex = Mutex()
   private var refreshJob: Deferred<Unit>? = null
+
+  private val syncProgressFlow = MutableStateFlow<SyncProgress?>(null)
+
+  override fun syncProgress(): StateFlow<SyncProgress?> = syncProgressFlow.asStateFlow()
 
   override suspend fun count(): Long = withContext(dispatchers.database) { dao.count() }
 
@@ -68,8 +83,13 @@ class NowPlayingRepositoryImpl(
 
   private suspend fun fetchAndReconcile(progress: Progress?) {
     val added = epoch()
+    // Indeterminate until the first page reports a server total.
+    syncProgressFlow.value = SyncProgress(current = 0, total = 0)
     playbackApi
-      .getNowPlayingList(progress)
+      .getNowPlayingList { current, total ->
+        syncProgressFlow.value = SyncProgress(current, total)
+        progress?.invoke(current, total)
+      }
       .onCompletion { cause ->
         // Only prune stale rows after a clean run. A cancelled (superseded) or failed refresh
         // must leave the existing queue intact — the replacing/next successful refresh prunes.
@@ -77,6 +97,11 @@ class NowPlayingRepositoryImpl(
           withContext(dispatchers.database) {
             dao.removePreviousEntries(added)
           }
+        }
+        // Hide the bar when this refresh ends — but not when it was superseded: the cancelling
+        // refresh has already set its own progress and now owns the indicator.
+        if (cause !is CancellationException) {
+          syncProgressFlow.value = null
         }
       }.collect { item ->
         val entities = item.map { it.toEntity().copy(dateAdded = added) }

--- a/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingViewModel.kt
+++ b/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingViewModel.kt
@@ -170,6 +170,7 @@ class NowPlayingViewModel(
   val tracks: Flow<PagingData<NowPlaying>> = repository.getAll().cachedIn(viewModelScope)
   val playingTrack = appState.playingTrack
   val connectionState = connectionStateFlow.connection
+  val syncProgress: StateFlow<SyncProgress?> = repository.syncProgress()
   val trackCount: StateFlow<Int> = repository.observeCount()
     .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0)
   val actions: NowPlayingActions =

--- a/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/SyncProgress.kt
+++ b/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/SyncProgress.kt
@@ -1,0 +1,16 @@
+package com.kelsos.mbrc.feature.playback.nowplaying
+
+/**
+ * Progress of an in-flight now-playing refresh. `null` (see [NowPlayingRepository.syncProgress])
+ * means no refresh is running.
+ *
+ * [total] is the server-reported queue size for the current page; it is `0` until the first page
+ * arrives, which [isDeterminate] reports as an indeterminate state so the UI can show a spinning
+ * bar until a real total is known.
+ */
+data class SyncProgress(val current: Int, val total: Int) {
+  val isDeterminate: Boolean get() = total > 0
+
+  val fraction: Float
+    get() = if (total > 0) (current.toFloat() / total).coerceIn(0f, 1f) else 0f
+}

--- a/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/compose/NowPlayingScreen.kt
+++ b/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/compose/NowPlayingScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SwipeToDismissBox
@@ -90,6 +91,7 @@ import com.kelsos.mbrc.feature.minicontrol.MiniControl
 import com.kelsos.mbrc.feature.playback.R
 import com.kelsos.mbrc.feature.playback.nowplaying.NowPlayingUiMessages
 import com.kelsos.mbrc.feature.playback.nowplaying.NowPlayingViewModel
+import com.kelsos.mbrc.feature.playback.nowplaying.SyncProgress
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
@@ -108,6 +110,7 @@ fun NowPlayingScreen(
   )
   val isConnected = connectionState is ConnectionStatus.Connected
   val trackCount by viewModel.trackCount.collectAsStateWithLifecycle()
+  val syncProgress by viewModel.syncProgress.collectAsStateWithLifecycle()
 
   var isRefreshing by remember { mutableStateOf(false) }
   var isSearchActive by rememberSaveable { mutableStateOf(false) }
@@ -168,6 +171,8 @@ fun NowPlayingScreen(
     actionItems = actionItems
   ) { paddingValues ->
     Column(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+      SyncProgressBar(syncProgress)
+
       NowPlayingContent(
         tracks = tracks,
         playingTrackPath = playingTrack.path,
@@ -252,6 +257,19 @@ private fun NowPlayingEventsEffect(
         }
       }
     }
+  }
+}
+
+@Composable
+internal fun SyncProgressBar(syncProgress: SyncProgress?) {
+  val progress = syncProgress ?: return
+  if (progress.isDeterminate) {
+    LinearProgressIndicator(
+      progress = { progress.fraction },
+      modifier = Modifier.fillMaxWidth()
+    )
+  } else {
+    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
   }
 }
 

--- a/feature/playback/src/test/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingRepositoryTest.kt
+++ b/feature/playback/src/test/kotlin/com/kelsos/mbrc/feature/playback/nowplaying/NowPlayingRepositoryTest.kt
@@ -5,6 +5,7 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.kelsos.mbrc.core.common.data.Progress
 import com.kelsos.mbrc.core.common.test.testDispatcher
 import com.kelsos.mbrc.core.common.test.testDispatcherModule
 import com.kelsos.mbrc.core.data.Database
@@ -675,6 +676,43 @@ class NowPlayingRepositoryTest : KoinTest {
       val resynced = dao.all().sortedBy { it.position }
       assertThat(resynced.map { it.position }).containsExactly(1, 5, 10).inOrder()
       assertThat(resynced.map { it.id }).containsExactly(1L, 5L, 10L).inOrder()
+    }
+  }
+
+  @Test
+  fun syncProgressReflectsRefreshAndClearsOnCompletion() {
+    runTest(testDispatcher) {
+      // Park the refresh after its first page so we can observe a non-null progress value, the way
+      // the screen would while a sync is in flight. The flow drives the progress callback exactly
+      // as ApiBase.getAllPages does on the real path.
+      val blocker = CompletableDeferred<Unit>()
+      val page = listOf(NowPlayingDto("T1", "A", "/remote/t1.mp3", 1))
+      every { playbackApi.getNowPlayingList(any()) } answers {
+        val callback = firstArg<Progress?>()
+        flow {
+          callback?.invoke(1, 1)
+          emit(page)
+          blocker.await()
+        }
+      }
+      dao.deleteAll()
+
+      assertThat(repository.syncProgress().value).isNull()
+
+      val inflight = launch { repository.getRemote(null) }
+      advanceUntilIdle()
+
+      val progress = repository.syncProgress().value
+      assertThat(progress).isNotNull()
+      assertThat(progress!!.current).isEqualTo(1)
+      assertThat(progress.total).isEqualTo(1)
+      assertThat(progress.isDeterminate).isTrue()
+
+      blocker.complete(Unit)
+      advanceUntilIdle()
+
+      assertThat(repository.syncProgress().value).isNull()
+      inflight.join()
     }
   }
 


### PR DESCRIPTION
## Summary

Surfaces the page-load progress of an in-flight now-playing refresh so a long sync gives visible feedback instead of appearing stalled. The bar appears at the top of the now playing queue for all three triggers: opening the screen, pull-to-refresh, and a server-side `nowplayinglistchanged` ("play all") broadcast.

## Details

- New `SyncProgress` value type with `isDeterminate`/`fraction` helpers.
- `NowPlayingRepository` exposes a single `syncProgress(): StateFlow<SyncProgress?>` shared across all triggers (`null` = idle).
- Progress starts **indeterminate** (no total yet), becomes **determinate** once the server reports a page total, and clears on clean completion — but **not** when the refresh is superseded (`CancellationException`), so the cancelling refresh keeps ownership of the indicator. This composes with the single-flight cancel-and-restart behaviour from #317.
- `NowPlayingScreen` renders a `LinearProgressIndicator` (determinate or spinning) above the queue.

## Testing

- New repository test: progress reflects the in-flight refresh and clears on completion.
- `./gradlew verifyLocal` — green (format, lint, detekt, tests, screenshots).

## Changelog

Staged under 1.6.1 (`Added`).