### PR TITLE
fix(widgets): rebuild widgets on app update to clear stale actions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,6 +59,7 @@
       android:exported="true">
       <intent-filter>
         <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+        <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
       </intent-filter>
 
       <meta-data
@@ -80,6 +81,7 @@
       android:exported="true">
       <intent-filter>
         <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+        <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
       </intent-filter>
 
       <meta-data

--- a/feature/widgets/src/main/kotlin/com/kelsos/mbrc/feature/widgets/glance/MusicWidgetReceiver.kt
+++ b/feature/widgets/src/main/kotlin/com/kelsos/mbrc/feature/widgets/glance/MusicWidgetReceiver.kt
@@ -1,0 +1,46 @@
+package com.kelsos.mbrc.feature.widgets.glance
+
+import android.content.Context
+import android.content.Intent
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.updateAll
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * Base widget receiver that rebuilds the widget after the app package is replaced.
+ *
+ * When the app is updated the launcher can keep the widget's previous RemoteViews,
+ * whose click PendingIntent templates no longer carry the target intent Glance expects.
+ * Tapping such a stale widget then crashes in `InvisibleActionTrampolineActivity` with
+ * "List adapter activity trampoline invoked without specifying target intent.".
+ *
+ * [GlanceAppWidgetReceiver] already refreshes on `ACTION_LOCALE_CHANGED` but does nothing
+ * for `ACTION_MY_PACKAGE_REPLACED`, so we handle it here and force [updateAll] to
+ * regenerate the RemoteViews (and their PendingIntents) for every widget instance.
+ */
+abstract class MusicWidgetReceiver : GlanceAppWidgetReceiver() {
+  override fun onReceive(context: Context, intent: Intent) {
+    super.onReceive(context, intent)
+    if (intent.action == Intent.ACTION_MY_PACKAGE_REPLACED) {
+      refreshAfterPackageReplaced(context)
+    }
+  }
+
+  @Suppress("TooGenericExceptionCaught") // A widget refresh must never crash the receiver.
+  private fun refreshAfterPackageReplaced(context: Context) {
+    val pendingResult = goAsync()
+    CoroutineScope(SupervisorJob() + Dispatchers.Default).launch {
+      try {
+        glanceAppWidget.updateAll(context)
+      } catch (e: Exception) {
+        Timber.e(e, "Failed to refresh widget after package replace")
+      } finally {
+        pendingResult.finish()
+      }
+    }
+  }
+}

--- a/feature/widgets/src/main/kotlin/com/kelsos/mbrc/feature/widgets/glance/NormalWidgetReceiver.kt
+++ b/feature/widgets/src/main/kotlin/com/kelsos/mbrc/feature/widgets/glance/NormalWidgetReceiver.kt
@@ -1,12 +1,11 @@
 package com.kelsos.mbrc.feature.widgets.glance
 
 import androidx.glance.appwidget.GlanceAppWidget
-import androidx.glance.appwidget.GlanceAppWidgetReceiver
 
 /**
  * Receiver for the normal size music widget.
  * This is the entry point registered in AndroidManifest.xml.
  */
-class NormalWidgetReceiver : GlanceAppWidgetReceiver() {
+class NormalWidgetReceiver : MusicWidgetReceiver() {
   override val glanceAppWidget: GlanceAppWidget = NormalWidget()
 }

--- a/feature/widgets/src/main/kotlin/com/kelsos/mbrc/feature/widgets/glance/SmallWidgetReceiver.kt
+++ b/feature/widgets/src/main/kotlin/com/kelsos/mbrc/feature/widgets/glance/SmallWidgetReceiver.kt
@@ -1,12 +1,11 @@
 package com.kelsos.mbrc.feature.widgets.glance
 
 import androidx.glance.appwidget.GlanceAppWidget
-import androidx.glance.appwidget.GlanceAppWidgetReceiver
 
 /**
  * Receiver for the small size music widget.
  * This is the entry point registered in AndroidManifest.xml.
  */
-class SmallWidgetReceiver : GlanceAppWidgetReceiver() {
+class SmallWidgetReceiver : MusicWidgetReceiver() {
   override val glanceAppWidget: GlanceAppWidget = SmallWidget()
 }


### PR DESCRIPTION
## Summary

Attempts to fix the recurring Glance widget crash: tapping a home screen widget after the app updates crashes in the trampoline activity with `List adapter activity trampoline invoked without specifying target intent.`

After an app update the launcher can keep a widget's old RemoteViews, whose click `PendingIntent` templates no longer carry the target intent Glance expects. The prior fix (`3c59b7b3`, 1.6.0-rc.4) did not resolve this.

## Changes

- New `MusicWidgetReceiver` base class handling `ACTION_MY_PACKAGE_REPLACED`, calling `updateAll()` to regenerate RemoteViews (and their PendingIntents) for every widget instance.
- `NormalWidgetReceiver` / `SmallWidgetReceiver` now extend it.
- Manifest: register `android.intent.action.MY_PACKAGE_REPLACED` for both widget receivers.

## Notes

Kept **out of the changelog** — we are not 100% sure this fixes the bug yet, since it only reproduces after a real package replace. Needs on-device verification across an actual app update.

`./gradlew verifyLocal` passes.