### PR TITLE
fix(#321): prevent RemoteService FGS start crash on Android 12+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog
 - Fixes the now playing queue sometimes loading only part of the list. Refreshes triggered close together (opening the screen, pull-to-refresh, or a server-side queue change) could overlap and overwrite each other's writes; a newer refresh now cancels and restarts the in-flight one, so the full queue is always loaded. A failed or superseded refresh no longer clears the existing queue.
 - Fixes a spurious error being logged on every "play all" action. The play-all confirmation broadcast from the plugin is now handled instead of being treated as an unsupported message.
 - Fixes a crash when scrolling the now playing queue during a refresh. Reconciling the queue could briefly leave two entries at the same position, which the list could then show twice and crash on; each position now updates in place, so an entry is never duplicated.
+- Fixes a crash when the system restarted the background remote-control service while the app was not in the foreground (Android 12+). The service no longer asks to be auto-recreated in the background, where promoting it to a foreground service is rejected, and it stops gracefully instead of crashing if a foreground start is denied.
 
 ## [1.6.0] - 2026-06-01
 ### Added

--- a/app/src/main/kotlin/com/kelsos/mbrc/service/RemoteService.kt
+++ b/app/src/main/kotlin/com/kelsos/mbrc/service/RemoteService.kt
@@ -18,19 +18,18 @@ class RemoteService : Service() {
   private val appStateManager: AppStateManager by inject()
   private val notificationManager: AppNotificationManager by inject()
   private val connectionManager: ClientConnectionManager by inject()
-  private lateinit var handler: Handler
+  private val handler = Handler(Looper.getMainLooper())
+  private var receiverRegistered = false
 
   override fun onBind(intent: Intent?): IBinder? = null
 
   override fun onCreate() {
     super.onCreate()
     Timber.d("Background Service::Created")
-    startForeground(
-      AppNotificationManager.MEDIA_SESSION_NOTIFICATION_ID,
-      notificationManager.createPlaceholder()
-    )
-    val looper = requireNotNull(Looper.myLooper())
-    handler = Handler(looper)
+    if (!startForegroundSafely()) {
+      stopSelf()
+      return
+    }
     ServiceState.setRunning(true)
     ContextCompat.registerReceiver(
       this,
@@ -38,18 +37,40 @@ class RemoteService : Service() {
       receiver.filter(this),
       ContextCompat.RECEIVER_EXPORTED
     )
+    receiverRegistered = true
   }
 
   override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
     Timber.d("Background Service::Started")
     notificationManager.initialize()
+    if (!startForegroundSafely()) {
+      stopSelf()
+      return START_NOT_STICKY
+    }
+    appStateManager.start()
+    connectionManager.start()
+    // START_NOT_STICKY: this is a user-facing remote-control service. If the process is killed
+    // we must NOT let the framework recreate it in the background, where startForeground() is
+    // rejected on Android 12+ (ForegroundServiceStartNotAllowedException). It is started again
+    // from the UI when the user reopens the app.
+    return START_NOT_STICKY
+  }
+
+  /**
+   * Promotes the service to the foreground, tolerating Android 12+ rejecting the start while the
+   * app is in the background (e.g. a backgrounded start race). [startForeground] throws
+   * `ForegroundServiceStartNotAllowedException`, an [IllegalStateException] subclass, in that case;
+   * we stop rather than crash. Returns true when the service successfully entered the foreground.
+   */
+  private fun startForegroundSafely(): Boolean = try {
     startForeground(
       AppNotificationManager.MEDIA_SESSION_NOTIFICATION_ID,
       notificationManager.createPlaceholder()
     )
-    appStateManager.start()
-    connectionManager.start()
-    return super.onStartCommand(intent, flags, startId)
+    true
+  } catch (e: IllegalStateException) {
+    Timber.w(e, "startForeground rejected (background start on Android 12+); stopping service")
+    false
   }
 
   override fun onDestroy() {
@@ -59,7 +80,10 @@ class RemoteService : Service() {
     connectionManager.stop()
     ServiceState.setStopping(true)
     ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
-    this.unregisterReceiver(receiver)
+    if (receiverRegistered) {
+      unregisterReceiver(receiver)
+      receiverRegistered = false
+    }
     handler.postDelayed(
       {
         ServiceState.setStopping(false)

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -8,6 +8,7 @@
     <bug>Fixes the now playing queue sometimes loading only part of the list. Refreshes triggered close together no longer overlap and overwrite each other; a newer refresh cancels and restarts the in-flight one, so the full queue is always loaded.</bug>
     <bug>Fixes a spurious error logged on every "play all" action by handling the play-all confirmation broadcast instead of treating it as an unsupported message.</bug>
     <bug>Fixes a crash when scrolling the now playing queue during a refresh. Reconciling the queue could briefly leave two entries at the same position; each position now updates in place, so an entry is never duplicated.</bug>
+    <bug>Fixes a crash when the system restarted the background remote-control service while the app was not in the foreground (Android 12+). The service no longer asks to be auto-recreated in the background and stops gracefully instead of crashing if a foreground start is denied.</bug>
   </version>
   <version
     version="1.6.0"

--- a/app/src/test/kotlin/com/kelsos/mbrc/service/RemoteServiceTest.kt
+++ b/app/src/test/kotlin/com/kelsos/mbrc/service/RemoteServiceTest.kt
@@ -1,0 +1,90 @@
+package com.kelsos.mbrc.service
+
+import android.app.Application
+import android.app.Service
+import android.content.Intent
+import android.content.IntentFilter
+import androidx.core.app.NotificationCompat
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.kelsos.mbrc.core.networking.ClientConnectionManager
+import com.kelsos.mbrc.service.mediasession.AppNotificationManager
+import com.kelsos.mbrc.state.AppStateManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.koin.test.KoinTest
+import org.robolectric.Robolectric
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(AndroidJUnit4::class)
+class RemoteServiceTest : KoinTest {
+  private val receiver: NotificationActionReceiver = mockk(relaxed = true)
+  private val appStateManager: AppStateManager = mockk(relaxed = true)
+  private val notificationManager: AppNotificationManager = mockk(relaxed = true)
+  private val connectionManager: ClientConnectionManager = mockk(relaxed = true)
+
+  private val testModule = module {
+    single { receiver }
+    single { appStateManager }
+    single { notificationManager }
+    single { connectionManager }
+  }
+
+  @Before
+  fun setUp() {
+    val context = ApplicationProvider.getApplicationContext<Application>()
+    val channelId = "test-channel"
+    val placeholder = NotificationCompat.Builder(context, channelId)
+      .setSmallIcon(android.R.drawable.ic_media_play)
+      .build()
+    every { notificationManager.createPlaceholder() } returns placeholder
+    every { receiver.filter(any()) } returns IntentFilter()
+
+    startKoin { modules(testModule) }
+    ServiceState.setRunning(false)
+    ServiceState.setStopping(false)
+  }
+
+  @After
+  fun tearDown() {
+    ServiceState.setRunning(false)
+    ServiceState.setStopping(false)
+    stopKoin()
+  }
+
+  @Test
+  fun `onStartCommand returns START_NOT_STICKY so the framework will not restart in background`() {
+    val service = Robolectric.buildService(RemoteService::class.java).create().get()
+
+    val result = service.onStartCommand(Intent(), 0, 1)
+
+    assertThat(result).isEqualTo(Service.START_NOT_STICKY)
+  }
+
+  @Test
+  fun `onCreate promotes the service to the foreground and marks it running`() {
+    val service = Robolectric.buildService(RemoteService::class.java).create().get()
+
+    assertThat(shadowOf(service).lastForegroundNotification).isNotNull()
+    assertThat(ServiceState.isRunning).isTrue()
+  }
+
+  @Test
+  fun `onStartCommand starts connection and app state`() {
+    val service = Robolectric.buildService(RemoteService::class.java).create().get()
+
+    service.onStartCommand(Intent(), 0, 1)
+
+    verify { appStateManager.start() }
+    verify { connectionManager.start() }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the #1 crash on 1.6.0 — `ForegroundServiceStartNotAllowedException` from `RemoteService` (Crashlytics, `processState: BACKGROUND`, seen on Android 12+).

**Root cause:** `onStartCommand` returned the default `START_STICKY`, so after a process kill the framework auto-recreated this user-facing foreground service **in the background**, where `startForeground()` is rejected on Android 12+.

## Changes

- `onStartCommand` now returns **`START_NOT_STICKY`** — the framework no longer recreates the service in the background; the UI starts it again when the user reopens the app.
- New `startForegroundSafely()` wraps **both** `startForeground()` calls, catches the Android 12+ rejection (`ForegroundServiceStartNotAllowedException`, an `IllegalStateException` subclass) and `stopSelf()`s instead of crashing on a backgrounded start race.
- Lifecycle hardening so the early-bail can't crash later: `handler` built at construction (no longer `lateinit`); `unregisterReceiver` guarded by a `receiverRegistered` flag.

## Testing

- `RemoteServiceTest` (Robolectric + Koin, 3 tests): `onStartCommand` returns `START_NOT_STICKY`; `onCreate` promotes to foreground + marks running; `onStartCommand` starts connection + app state.
- `./gradlew :app:lintKotlin :app:compileGithubDebugKotlin :app:testGithubDebugUnitTest` — all green.
- Manual on AVD (Android 12): pre-fix build schedules a background restart after a process kill; fixed build does not. Forcing `startForeground()` denial (`appops START_FOREGROUND ignore`) on the fixed build does not crash.

Closes #321
