### PR TITLE
chore: prepare 1.6.1 release (versionCode 131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 -----------
 
-## [1.6.1]
+## [1.6.1] - 2026-06-27
 ### Added
 - Shows a progress bar at the top of the now playing queue while it is syncing, so a long sync (opening the screen, pull-to-refresh, or a server-side "play all") gives visible feedback instead of appearing stalled. The bar reflects the actual page-load progress reported by the server.
 
@@ -296,7 +296,8 @@ Changelog
 - Removes the dialogs that used to appear on each new setup.
 
 
-[Unreleased]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/musicbeeremote/mbrc/compare/v1.6.1...HEAD
+[1.6.1]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0-rc.4...v1.6.0
 [1.6.0-rc.4]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0-rc.3...v1.6.0-rc.4
 [1.6.0-rc.3]: https://github.com/musicbeeremote/mbrc/compare/v1.6.0-rc.2...v1.6.0-rc.3

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -92,8 +92,8 @@ val buildTimeProvider = providers.provider {
   df.format(Date())
 }
 
-val appVersionName = "1.6.0"
-val appVersionCode = 130
+val appVersionName = "1.6.1"
+val appVersionCode = 131
 val minSDKVersion = 23
 val compileSDKVersion = 36
 

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -2,7 +2,7 @@
 <changelog>
   <version
     version="1.6.1"
-    release="unreleased">
+    release="Jun 27, 2026">
     <feature>Shows a progress bar at the top of the now playing queue while it syncs, so a long sync (opening the screen, pull-to-refresh, or a server-side "play all") gives visible feedback instead of appearing stalled.</feature>
     <bug>Fixes out-of-memory crashes on very large now playing queues. The queue now syncs one page at a time instead of loading the whole list into memory, so memory stays flat regardless of queue size. Incoming network messages are also capped relative to the available heap as a safeguard.</bug>
     <bug>Fixes the now playing queue sometimes loading only part of the list. Refreshes triggered close together no longer overlap and overwrite each other; a newer refresh cancels and restarts the in-flight one, so the full queue is always loaded.</bug>


### PR DESCRIPTION
Prepares the 1.6.1 release.

## Changes
- Bump `appVersionName` 1.6.0 → 1.6.1 and `appVersionCode` 130 → 131
- Stamp `CHANGELOG.md` 1.6.1 with release date 2026-06-27 and add compare links (`[Unreleased]` now from v1.6.1, new `[1.6.1]` entry)
- Stamp in-app `changelog.xml` 1.6.1 `release="Jun 27, 2026"`

## Contents of 1.6.1
All fixes were already merged to `main` via #316–#322; this PR only stamps versions/dates:
- Now-playing OOM fix (per-page reconcile + bounded inbound reads)
- Now-playing partial-load fix (single-flight cancel-and-restart refresh)
- Duplicate-key LazyColumn crash fix (reconcile keyed by position)
- Sync progress bar on the now-playing queue
- Play-all confirmation broadcast handled (no more spurious error log)
- RemoteService foreground-service start crash fix (Android 12+, #321)

## Validation
- `:feature:misc:testDebugUnitTest --tests "*ChangelogParser*"` passes against the edited XML