### PR TITLE
fix(#327): restore long-press-to-stop on play/pause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 -----------
 
+## [1.7.0]
+### Fixed
+- Restores long-press-to-stop on the play/pause button. Long-pressing play/pause on the player and the mini-control now stops playback, a gesture that was lost when the player moved to the new UI. A short tap still toggles play/pause.
+
 ## [1.6.1] - 2026-06-27
 ### Added
 - Shows a progress bar at the top of the now playing queue while it is syncing, so a long sync (opening the screen, pull-to-refresh, or a server-side "play all") gives visible feedback instead of appearing stalled. The bar reflects the actual page-load progress reported by the server.

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <changelog>
   <version
+    version="1.7.0"
+    release="unreleased">
+    <bug>Restores long-press-to-stop on the play/pause button (player and mini-control). Long-pressing play/pause now stops playback, a gesture lost when the player moved to the new UI; a short tap still toggles play/pause.</bug>
+  </version>
+  <version
     version="1.6.1"
     release="Jun 27, 2026">
     <feature>Shows a progress bar at the top of the now playing queue while it syncs, so a long sync (opening the screen, pull-to-refresh, or a server-side "play all") gives visible feedback instead of appearing stalled.</feature>

--- a/app/src/screenshotTest/kotlin/com/kelsos/mbrc/screenshots/MiniControlScreenshotPreviews.kt
+++ b/app/src/screenshotTest/kotlin/com/kelsos/mbrc/screenshots/MiniControlScreenshotPreviews.kt
@@ -28,6 +28,7 @@ fun MiniControlPlayingLightPreview() {
       onNavigateToPlayer = {},
       onPreviousClick = {},
       onPlayPauseClick = {},
+      onPlayPauseLongClick = {},
       onNextClick = {}
     )
   }
@@ -51,6 +52,7 @@ fun MiniControlPlayingDarkPreview() {
       onNavigateToPlayer = {},
       onPreviousClick = {},
       onPlayPauseClick = {},
+      onPlayPauseLongClick = {},
       onNextClick = {}
     )
   }
@@ -74,6 +76,7 @@ fun MiniControlPausedLightPreview() {
       onNavigateToPlayer = {},
       onPreviousClick = {},
       onPlayPauseClick = {},
+      onPlayPauseLongClick = {},
       onNextClick = {}
     )
   }
@@ -97,6 +100,7 @@ fun MiniControlPausedDarkPreview() {
       onNavigateToPlayer = {},
       onPreviousClick = {},
       onPlayPauseClick = {},
+      onPlayPauseLongClick = {},
       onNextClick = {}
     )
   }

--- a/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/protocol/usecases/UserActionUseCase.kt
+++ b/core/networking/src/main/kotlin/com/kelsos/mbrc/core/networking/protocol/usecases/UserActionUseCase.kt
@@ -44,6 +44,10 @@ suspend fun UserActionUseCase.playPause() {
   perform(UserAction.create(Protocol.PlayerPlayPause))
 }
 
+suspend fun UserActionUseCase.stop() {
+  perform(UserAction.create(Protocol.PlayerStop))
+}
+
 suspend fun UserActionUseCase.play() {
   perform(UserAction.create(Protocol.PlayerPlay))
 }

--- a/feature/minicontrol/src/main/kotlin/com/kelsos/mbrc/feature/minicontrol/MiniControl.kt
+++ b/feature/minicontrol/src/main/kotlin/com/kelsos/mbrc/feature/minicontrol/MiniControl.kt
@@ -2,6 +2,8 @@ package com.kelsos.mbrc.feature.minicontrol
 
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -18,18 +20,22 @@ import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -65,6 +71,7 @@ fun MiniControl(
     onNavigateToPlayer = onNavigateToPlayer,
     onPreviousClick = { viewModel.perform(MiniControlAction.PlayPrevious) },
     onPlayPauseClick = { viewModel.perform(MiniControlAction.PlayPause) },
+    onPlayPauseLongClick = { viewModel.perform(MiniControlAction.Stop) },
     onNextClick = { viewModel.perform(MiniControlAction.PlayNext) },
     modifier = modifier
   )
@@ -76,6 +83,7 @@ fun MiniControlContent(
   onNavigateToPlayer: () -> Unit,
   onPreviousClick: () -> Unit,
   onPlayPauseClick: () -> Unit,
+  onPlayPauseLongClick: () -> Unit,
   onNextClick: () -> Unit,
   modifier: Modifier = Modifier
 ) {
@@ -171,7 +179,25 @@ fun MiniControlContent(
           )
         }
 
-        IconButton(onClick = onPlayPauseClick) {
+        // Tap toggles play/pause, long-press stops playback (restores the legacy gesture).
+        // IconButton has no onLongClick, so we replicate its exact layout (minimum interactive
+        // size + 40.dp container + standard shape) and drive both gestures via combinedClickable.
+        val haptics = LocalHapticFeedback.current
+        Box(
+          modifier = Modifier
+            .minimumInteractiveComponentSize()
+            .size(40.dp)
+            .clip(IconButtonDefaults.standardShape)
+            .combinedClickable(
+              onClick = onPlayPauseClick,
+              onLongClick = {
+                haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                onPlayPauseLongClick()
+              },
+              onLongClickLabel = stringResource(R.string.main_button_stop_description)
+            ),
+          contentAlignment = Alignment.Center
+        ) {
           Icon(
             imageVector = if (state.playingState == PlayerState.Playing) {
               Icons.Default.Pause

--- a/feature/minicontrol/src/main/kotlin/com/kelsos/mbrc/feature/minicontrol/MiniControlAction.kt
+++ b/feature/minicontrol/src/main/kotlin/com/kelsos/mbrc/feature/minicontrol/MiniControlAction.kt
@@ -6,4 +6,6 @@ sealed class MiniControlAction {
   data object PlayNext : MiniControlAction()
 
   data object PlayPause : MiniControlAction()
+
+  data object Stop : MiniControlAction()
 }

--- a/feature/minicontrol/src/main/kotlin/com/kelsos/mbrc/feature/minicontrol/MiniControlViewModel.kt
+++ b/feature/minicontrol/src/main/kotlin/com/kelsos/mbrc/feature/minicontrol/MiniControlViewModel.kt
@@ -15,6 +15,7 @@ import com.kelsos.mbrc.core.networking.protocol.usecases.UserActionUseCase
 import com.kelsos.mbrc.core.networking.protocol.usecases.next
 import com.kelsos.mbrc.core.networking.protocol.usecases.playPause
 import com.kelsos.mbrc.core.networking.protocol.usecases.previous
+import com.kelsos.mbrc.core.networking.protocol.usecases.stop
 import java.io.IOException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -59,6 +60,7 @@ class MiniControlViewModel(
           MiniControlAction.PlayNext -> userActionUseCase.next()
           MiniControlAction.PlayPause -> userActionUseCase.playPause()
           MiniControlAction.PlayPrevious -> userActionUseCase.previous()
+          MiniControlAction.Stop -> userActionUseCase.stop()
         }
       } catch (e: IOException) {
         Timber.e(e)

--- a/feature/minicontrol/src/main/res/values/strings.xml
+++ b/feature/minicontrol/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
   <string name="main_button_next_description">Play next track</string>
   <string name="main_button_play_pause_description">Play or pause</string>
   <string name="main_button_previous_description">Play previous track</string>
+  <string name="main_button_stop_description">Stop playback</string>
 
   <!-- Unknown values -->
   <string name="unknown_artist">Unknown artist</string>

--- a/feature/minicontrol/src/test/kotlin/com/kelsos/mbrc/feature/minicontrol/MiniControlViewModelTest.kt
+++ b/feature/minicontrol/src/test/kotlin/com/kelsos/mbrc/feature/minicontrol/MiniControlViewModelTest.kt
@@ -15,6 +15,7 @@ import com.kelsos.mbrc.core.networking.protocol.usecases.UserActionUseCase
 import com.kelsos.mbrc.core.networking.protocol.usecases.next
 import com.kelsos.mbrc.core.networking.protocol.usecases.playPause
 import com.kelsos.mbrc.core.networking.protocol.usecases.previous
+import com.kelsos.mbrc.core.networking.protocol.usecases.stop
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -299,6 +300,68 @@ class MiniControlViewModelTest : KoinTest {
 
       // Verify user action was called
       coVerify(exactly = 1) { userActionUseCase.previous() }
+    }
+  }
+
+  @Test
+  fun performStopShouldEmitNetworkUnavailableWhenNotConnected() {
+    runTest(testDispatcher) {
+      // Given
+      coEvery { connectionStateFlow.isConnected } returns false
+
+      // When & Then
+      viewModel.events.test {
+        viewModel.perform(MiniControlAction.Stop)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val event = awaitItem()
+        assertThat(event).isEqualTo(MiniControlUiMessages.NetworkUnavailable)
+      }
+
+      // Verify user action is not called when not connected
+      coVerify(exactly = 0) { userActionUseCase.stop() }
+    }
+  }
+
+  @Test
+  fun performStopShouldNotEmitWhenConnectedAndUserActionSucceeds() {
+    runTest(testDispatcher) {
+      // Given
+      coEvery { connectionStateFlow.isConnected } returns true
+      coEvery { userActionUseCase.stop() } returns Unit
+
+      // When & Then
+      viewModel.events.test {
+        viewModel.perform(MiniControlAction.Stop)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Should not emit any events on successful action
+        expectNoEvents()
+      }
+
+      // Verify user action was called
+      coVerify(exactly = 1) { userActionUseCase.stop() }
+    }
+  }
+
+  @Test
+  fun performStopShouldEmitActionFailedWhenConnectedButUserActionThrowsIOException() {
+    runTest(testDispatcher) {
+      // Given
+      coEvery { connectionStateFlow.isConnected } returns true
+      coEvery { userActionUseCase.stop() } throws IOException("Network error")
+
+      // When & Then
+      viewModel.events.test {
+        viewModel.perform(MiniControlAction.Stop)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val event = awaitItem()
+        assertThat(event).isEqualTo(MiniControlUiMessages.ActionFailed)
+      }
+
+      // Verify user action was called
+      coVerify(exactly = 1) { userActionUseCase.stop() }
     }
   }
 

--- a/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/player/compose/PlayerScreen.kt
+++ b/feature/playback/src/main/kotlin/com/kelsos/mbrc/feature/playback/player/compose/PlayerScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -46,10 +47,8 @@ import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material.icons.filled.SpeakerGroup
 import androidx.compose.material.icons.filled.ThumbDown
 import androidx.compose.material.icons.outlined.Lyrics
-import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
@@ -68,9 +67,11 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -1131,24 +1132,36 @@ private fun PlaybackControls(playbackState: PlaybackState, actions: IPlayerActio
     }
 
     // Play/Pause button - large filled circle
-    FilledIconButton(
-      onClick = actions.playPause,
-      modifier = Modifier.size(64.dp),
+    // Tap toggles play/pause, long-press stops playback (restores the legacy gesture).
+    // FilledIconButton has no onLongClick, so we render the same filled circle with a Surface
+    // (identical shape rasterization) and drive both gestures via combinedClickable.
+    val haptics = LocalHapticFeedback.current
+    Surface(
       shape = CircleShape,
-      colors = IconButtonDefaults.filledIconButtonColors(
-        containerColor = MaterialTheme.colorScheme.onSurface,
-        contentColor = MaterialTheme.colorScheme.surface
-      )
+      color = MaterialTheme.colorScheme.onSurface,
+      contentColor = MaterialTheme.colorScheme.surface,
+      modifier = Modifier
+        .size(64.dp)
+        .combinedClickable(
+          onClick = actions.playPause,
+          onLongClick = {
+            haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+            actions.stop()
+          },
+          onLongClickLabel = stringResource(R.string.main_button_stop_description)
+        )
     ) {
-      Icon(
-        imageVector = if (playbackState.playerState == PlayerState.Playing) {
-          Icons.Default.Pause
-        } else {
-          Icons.Default.PlayArrow
-        },
-        contentDescription = stringResource(R.string.main_button_play_pause_description),
-        modifier = Modifier.size(32.dp)
-      )
+      Box(contentAlignment = Alignment.Center) {
+        Icon(
+          imageVector = if (playbackState.playerState == PlayerState.Playing) {
+            Icons.Default.Pause
+          } else {
+            Icons.Default.PlayArrow
+          },
+          contentDescription = stringResource(R.string.main_button_play_pause_description),
+          modifier = Modifier.size(32.dp)
+        )
+      }
     }
 
     // Next button - larger

--- a/feature/playback/src/main/res/values/strings.xml
+++ b/feature/playback/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
   <string name="main_button_next_description">When pressed it plays the next track.</string>
   <string name="main_button_play_pause_description">When pressed either it starts playing a track or pauses it if it is already playing.</string>
   <string name="main_button_previous_description">When pressed it plays the previous track</string>
+  <string name="main_button_stop_description">When long-pressed it stops playback.</string>
   <string name="main_button_repeat_description">When pressed it changes the repeat (all/none).</string>
   <string name="main_button_shuffle_description">When pressed it changes the shuffle mode (on/off).</string>
   <string name="menu_overflow_description">More options</string>


### PR DESCRIPTION
## Summary

Restores the long-press-to-stop gesture on the play/pause button, a regression from the Compose migration (`af18af21`). The legacy View-based player wired `setOnLongClickListener { stop() }` on play/pause; the Compose buttons only carried over `onClick`, so the gesture was lost on every surface.

- **Tap** play/pause: toggle play/pause (unchanged)
- **Long-press** play/pause: stop playback, with haptic feedback and a stop accessibility action

Applied to both surfaces:
- Now Playing / main player (`PlayerScreen.kt`)
- Mini Control (`MiniControl.kt`)

The stop plumbing already existed (`Protocol.PlayerStop`); this just makes it reachable from touch again.

## Implementation

`IconButton` / `FilledIconButton` don't expose `onLongClick`, so the buttons are rebuilt with `Modifier.combinedClickable`. To keep the change invisible to the screenshot tests, each replacement reproduces the component's exact render path rather than a generic `Box`:
- Player: `Surface(shape = CircleShape, ...)` matches `FilledIconButton`'s internal shape rasterization.
- Mini Control: `minimumInteractiveComponentSize().size(40.dp).clip(IconButtonDefaults.standardShape)` is the literal M3 `IconButton` modifier chain (default container is 40.dp, not 48.dp).

Added a `UserActionUseCase.stop()` extension and `MiniControlAction.Stop`.

## Tests

- 3 new `MiniControlViewModelTest` cases for the Stop action (not-connected / success / IOException), mirroring the existing per-action pattern.
- `verifyLocal` passes (format, lint, detekt, unit tests, screenshots).
- **Screenshot references are unchanged** (`validateGithubDebugScreenshotTest` green with no re-baseline).

Closes #327