### PR TITLE
fix(#333): run detekt on :app in staticAnalysisAll

### DIFF
--- a/app/src/main/kotlin/com/kelsos/mbrc/state/AppStateManager.kt
+++ b/app/src/main/kotlin/com/kelsos/mbrc/state/AppStateManager.kt
@@ -136,7 +136,7 @@ class AppStateManager(
     positionJob = null
   }
 
-  private suspend fun updatePosition() {
+  private fun updatePosition() {
     val position = appState.playingPosition.value
     // For streams (total <= 0), don't coerce - just increment the elapsed time
     val current = if (position.total <= 0) {

--- a/app/src/main/kotlin/com/kelsos/mbrc/ui/RemoteApp.kt
+++ b/app/src/main/kotlin/com/kelsos/mbrc/ui/RemoteApp.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalNavigationDrawer
@@ -22,7 +23,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.AwaitPointerEventScope
 import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerId
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.unit.dp
@@ -117,45 +120,10 @@ fun RemoteApp() {
           )
         }
       ) {
-        // Left-edge swipe-to-open detector. Only arms on pointer-downs within
-        // DRAWER_EDGE_WIDTH of the left edge, and only commits if the gesture
-        // crosses touch slop while clearly rightward and horizontal — content
-        // swipes elsewhere on the screen don't open the drawer.
         Box(
           modifier = Modifier
             .fillMaxSize()
-            .pointerInput(drawerState) {
-              awaitPointerEventScope {
-                val edgePx = DRAWER_EDGE_WIDTH.toPx()
-                val slop = viewConfiguration.touchSlop
-                while (true) {
-                  val down = awaitFirstDown(pass = PointerEventPass.Initial)
-                  if (drawerState.isOpen || down.position.x > edgePx) continue
-                  // Track slop ourselves on the Initial pass so children
-                  // (raised-slop swipeable rows in now-playing) can't consume
-                  // the move events before we decide to claim the gesture.
-                  var totalX = 0f
-                  var totalY = 0f
-                  var armed = false
-                  while (!armed) {
-                    val event = awaitPointerEvent(PointerEventPass.Initial)
-                    val change = event.changes.firstOrNull { it.id == down.id } ?: break
-                    if (!change.pressed) break
-                    val delta = change.positionChange()
-                    totalX += delta.x
-                    totalY += delta.y
-                    if (totalX > slop && totalX > abs(totalY) * EDGE_HORIZONTAL_DOMINANCE) {
-                      change.consume()
-                      armed = true
-                    } else if (abs(totalY) > slop && abs(totalY) > abs(totalX)) {
-                      // Vertical-dominant gesture — let children handle it.
-                      break
-                    }
-                  }
-                  if (armed) scope.launch { drawerState.open() }
-                }
-              }
-            }
+            .leftEdgeDrawerSwipe(drawerState) { scope.launch { drawerState.open() } }
         ) {
           // Each screen handles its own Scaffold - no shared Scaffold here
           AppNavGraph(
@@ -208,5 +176,54 @@ fun RemoteApp() {
         )
       }
     }
+  }
+}
+
+/**
+ * Left-edge swipe-to-open detector for the navigation drawer. Only arms on
+ * pointer-downs within [DRAWER_EDGE_WIDTH] of the left edge, and only commits
+ * ([onOpen]) once the gesture crosses touch slop while clearly rightward and
+ * horizontal, so content swipes elsewhere on the screen don't open the drawer.
+ *
+ * Slop is tracked here on the Initial pass so children (raised-slop swipeable
+ * rows in now-playing) can't consume the move events before we claim the gesture.
+ */
+private fun Modifier.leftEdgeDrawerSwipe(drawerState: DrawerState, onOpen: () -> Unit): Modifier =
+  pointerInput(drawerState) {
+    awaitPointerEventScope {
+      val edgePx = DRAWER_EDGE_WIDTH.toPx()
+      val slop = viewConfiguration.touchSlop
+      while (true) {
+        val down = awaitFirstDown(pass = PointerEventPass.Initial)
+        if (drawerState.isOpen || down.position.x > edgePx) continue
+        if (awaitLeftEdgeArm(down.id, slop)) onOpen()
+      }
+    }
+  }
+
+/**
+ * Waits for the in-progress gesture started by [downId] to either arm as a
+ * rightward, horizontal-dominant drawer swipe (returns `true`, consuming the
+ * move) or resolve as vertical / released (returns `false`), letting children
+ * handle it.
+ */
+private suspend fun AwaitPointerEventScope.awaitLeftEdgeArm(
+  downId: PointerId,
+  slop: Float
+): Boolean {
+  var totalX = 0f
+  var totalY = 0f
+  while (true) {
+    val event = awaitPointerEvent(PointerEventPass.Initial)
+    val change = event.changes.firstOrNull { it.id == downId } ?: return false
+    if (!change.pressed) return false
+    val delta = change.positionChange()
+    totalX += delta.x
+    totalY += delta.y
+    if (totalX > slop && totalX > abs(totalY) * EDGE_HORIZONTAL_DOMINANCE) {
+      change.consume()
+      return true
+    }
+    if (abs(totalY) > slop && abs(totalY) > abs(totalX)) return false
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -118,12 +118,34 @@ dependencies {
 
 tasks.register("staticAnalysisAll") {
   description = "Runs detekt (with type resolution), lint, and kotlinter on all modules"
-  // detektDebug runs with type resolution, which is required for rules like
-  // RedundantSuspendModifier that inspect call sites. The bare `detekt` task
-  // skips type resolution and silently misses these.
-  dependsOn(subprojects.flatMap { it.tasks.matching { t -> t.name == "detektDebug" } })
   dependsOn(subprojects.flatMap { it.tasks.matching { t -> t.name == "lintKotlin" } })
   dependsOn(subprojects.flatMap { it.tasks.matching { t -> t.name == "lint" } })
+}
+
+// Attach one detekt task per subproject once every project is configured.
+//
+// detektDebug runs with type resolution, which is required for rules like
+// RedundantSuspendModifier that inspect call sites; the bare `detekt` task skips
+// type resolution and silently misses these. Unflavored library modules expose
+// `detektDebug`, but the flavored `:app` module only has per-flavor tasks
+// (`detektGithubDebug`, `detektPlayDebug`) and the baseline-profile test module
+// has neither. Matching on the literal name `detektDebug` therefore silently
+// skipped `:app` entirely (#333). Resolve one task per subproject with a
+// fallback chain and fail loudly if a module exposes no detekt task at all, so a
+// future naming change can never drop a module from analysis unnoticed.
+gradle.projectsEvaluated {
+  tasks.named("staticAnalysisAll").configure {
+    for (sub in subprojects) {
+      val detektTask = sub.tasks.findByName("detektDebug")
+        ?: sub.tasks.findByName("detektGithubDebug")
+        ?: sub.tasks.findByName("detekt")
+        ?: throw GradleException(
+          "staticAnalysisAll found no detekt task for ${sub.path}; refusing to " +
+            "silently skip it. Expected detektDebug, detektGithubDebug or detekt.",
+        )
+      dependsOn(detektTask)
+    }
+  }
 }
 
 abstract class CollectSarifReportsTask : DefaultTask() {
@@ -141,14 +163,17 @@ abstract class CollectSarifReportsTask : DefaultTask() {
 
     val buildDirs = subprojectBuildDirs.get()
 
-    // Collect and merge detekt SARIF reports. staticAnalysisAll runs
-    // :detektDebug (with type resolution), which emits debug.sarif;
-    // fall back to detekt.sarif for any module that ran the bare task.
+    // Collect and merge detekt SARIF reports. staticAnalysisAll runs the debug,
+    // type-resolution task per module: library modules emit debug.sarif, the
+    // flavored :app emits githubDebug.sarif; fall back to detekt.sarif for any
+    // module that ran the bare task (e.g. the baseline-profile module).
     val detektFiles = buildDirs.mapNotNull { buildDir ->
       val debugSarif = File(buildDir, "reports/detekt/debug.sarif")
+      val githubDebugSarif = File(buildDir, "reports/detekt/githubDebug.sarif")
       val baseSarif = File(buildDir, "reports/detekt/detekt.sarif")
       when {
         debugSarif.exists() -> debugSarif
+        githubDebugSarif.exists() -> githubDebugSarif
         baseSarif.exists() -> baseSarif
         else -> null
       }


### PR DESCRIPTION
## Summary

`staticAnalysisAll` has never run detekt on the `:app` module. It wired detekt by matching the literal task name `detektDebug`, which only exists on the unflavored library modules. The flavored `:app` module exposes `detektGithubDebug` / `detektPlayDebug`, so `tasks.matching { it.name == "detektDebug" }` returned an empty collection — no warning, no failure — and any violation living only in `:app` went unreported indefinitely (#333).

### Changes

- **Wire detekt per subproject, fail loudly.** After projects are evaluated, resolve one detekt task per subproject with a fallback chain (`detektDebug` → `detektGithubDebug` → bare `detekt`) and throw if a module exposes none, so a future task-naming change can never silently drop a module from analysis again. `:app` is now analyzed via `detektGithubDebug`; container projects and the baseline-profile module fall back to `detekt`.
- **Collect `githubDebug.sarif`** so `:app` detekt findings reach the merged SARIF report used for code scanning.
- **Fix the two violations this surfaces on `:app`** (both real; deliberately not baselined):
  - `RemoteApp` cyclomatic complexity 22 > 15 — extracted the inline left-edge drawer-swipe detector into a `Modifier.leftEdgeDrawerSwipe` extension plus a small helper. Behaviour unchanged.
  - Removed a redundant `suspend` modifier on `AppStateManager.updatePosition` — a `RedundantSuspendModifier` finding that is only detectable with type resolution, i.e. exactly the class of issue this CI gap was hiding.

### Testing

- `./gradlew staticAnalysisAll` is green end to end and now wires 17 detekt tasks (one per subproject, `:app` included); a dry run confirms `:app:detektGithubDebug` is present.
- `:app:detektGithubDebug` clean; `:app` unit tests pass.
- The `RemoteApp` gesture refactor is behaviour-preserving; the left-edge swipe-to-open and the now-playing row swipes were verified on-device (Pixel 10, Android 16).

Closes #333