### PR TITLE
chore: migrate to AGP 9.3.1 + Gradle 9.6.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.android.build.gradle.internal.api.BaseVariantOutputImpl
 import com.android.build.gradle.internal.tasks.factory.dependsOn
 import io.gitlab.arturbosch.detekt.Detekt
 import java.io.FileInputStream
@@ -7,10 +6,9 @@ import java.util.*
 
 plugins {
   alias(libs.plugins.android.application)
-  alias(libs.plugins.kotlinAndroid)
   alias(libs.plugins.kotlinParcelize)
   alias(libs.plugins.kotlinCompose)
-  alias(libs.plugins.ksp)
+  id("com.google.devtools.ksp")
   alias(libs.plugins.protobuf)
   alias(libs.plugins.googleServices) apply false
   alias(libs.plugins.crashlytics) apply false
@@ -256,17 +254,6 @@ android {
   lint {
     lintConfig = rootProject.file("config/lint.xml")
     sarifReport = true
-  }
-
-  applicationVariants.all {
-    val variant = this
-    variant.outputs.map { it as BaseVariantOutputImpl }
-      .forEach { output ->
-        val applicationId = defaultConfig.applicationId
-        val flavorName = variant.flavorName
-        val name = "$applicationId-$flavorName-${variant.versionCode}-v${variant.versionName}.apk"
-        output.outputFileName = name
-      }
   }
 }
 

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
   alias(libs.plugins.android.test)
-  alias(libs.plugins.kotlinAndroid)
   alias(libs.plugins.baselineprofile)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,11 @@ import kotlinx.serialization.json.putJsonArray
 buildscript {
   dependencies {
     classpath(libs.kotlinx.serialization.json)
+    // AGP 9 built-in Kotlin defaults to KGP 2.2.10; override it up to the project's Kotlin version.
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${libs.versions.kotlin.get()}")
+    classpath(
+      "com.google.devtools.ksp:symbol-processing-gradle-plugin:${libs.versions.gradlePlugin.ksp.get()}"
+    )
   }
 }
 
@@ -26,7 +31,6 @@ plugins {
   alias(libs.plugins.android.library) apply false
   alias(libs.plugins.android.test) apply false
   alias(libs.plugins.baselineprofile) apply false
-  alias(libs.plugins.kotlinAndroid) apply false
   alias(libs.plugins.kotlinter) apply false
   alias(libs.plugins.kotlinParcelize) apply false
   alias(libs.plugins.detekt)
@@ -60,13 +64,17 @@ allprojects {
 }
 
 subprojects {
-  pluginManager.withPlugin("org.jetbrains.kotlin.android") {
-    apply(plugin = "org.jmailen.kotlinter")
-    apply(plugin = "org.jetbrains.kotlinx.kover")
+  // With AGP 9 built-in Kotlin there is no kotlin.android plugin to hook; every Android
+  // module is a Kotlin module, so key kotlinter/kover off the Android plugins instead.
+  listOf("com.android.application", "com.android.library", "com.android.test").forEach { pluginId ->
+    pluginManager.withPlugin(pluginId) {
+      apply(plugin = "org.jmailen.kotlinter")
+      apply(plugin = "org.jetbrains.kotlinx.kover")
+    }
   }
 
   pluginManager.withPlugin("com.android.library") {
-    configure<com.android.build.gradle.LibraryExtension> {
+    configure<com.android.build.api.dsl.LibraryExtension> {
       lint {
         lintConfig = rootProject.file("config/lint.xml")
         sarifReport = true

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
   alias(libs.plugins.android.library)
-  alias(libs.plugins.kotlinAndroid)
 }
 
 android {

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
   alias(libs.plugins.android.library)
-  alias(libs.plugins.kotlinAndroid)
-  alias(libs.plugins.ksp)
+  id("com.google.devtools.ksp")
 }
 
 android {

--- a/core/networking/build.gradle.kts
+++ b/core/networking/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
   alias(libs.plugins.android.library)
-  alias(libs.plugins.kotlinAndroid)
-  alias(libs.plugins.ksp)
+  id("com.google.devtools.ksp")
 }
 
 android {

--- a/core/platform/build.gradle.kts
+++ b/core/platform/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
   alias(libs.plugins.android.library)
-  alias(libs.plugins.kotlinAndroid)
 }
 
 android {

--- a/core/queue/build.gradle.kts
+++ b/core/queue/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
   alias(libs.plugins.android.library)
-  alias(libs.plugins.kotlinAndroid)
 }
 
 android {

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
   alias(libs.plugins.android.library)
-  alias(libs.plugins.kotlinAndroid)
   alias(libs.plugins.kotlinCompose)
 }
 

--- a/feature/content/build.gradle.kts
+++ b/feature/content/build.gradle.kts
@@ -1,8 +1,7 @@
 plugins {
   alias(libs.plugins.android.library)
-  alias(libs.plugins.kotlinAndroid)
   alias(libs.plugins.kotlinCompose)
-  alias(libs.plugins.ksp)
+  id("com.google.devtools.ksp")
 }
 
 android {

--- a/feature/library/build.gradle.kts
+++ b/feature/library/build.gradle.kts
@@ -1,8 +1,7 @@
 plugins {
   alias(libs.plugins.android.library)
-  alias(libs.plugins.kotlinAndroid)
   alias(libs.plugins.kotlinCompose)
-  alias(libs.plugins.ksp)
+  id("com.google.devtools.ksp")
 }
 
 android {

--- a/feature/minicontrol/build.gradle.kts
+++ b/feature/minicontrol/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
   alias(libs.plugins.android.library)
-  alias(libs.plugins.kotlinAndroid)
   alias(libs.plugins.kotlinCompose)
 }
 

--- a/feature/misc/build.gradle.kts
+++ b/feature/misc/build.gradle.kts
@@ -1,8 +1,7 @@
 plugins {
   alias(libs.plugins.android.library)
-  alias(libs.plugins.kotlinAndroid)
   alias(libs.plugins.kotlinCompose)
-  alias(libs.plugins.ksp)
+  id("com.google.devtools.ksp")
 }
 
 android {

--- a/feature/playback/build.gradle.kts
+++ b/feature/playback/build.gradle.kts
@@ -1,8 +1,7 @@
 plugins {
   alias(libs.plugins.android.library)
-  alias(libs.plugins.kotlinAndroid)
   alias(libs.plugins.kotlinCompose)
-  alias(libs.plugins.ksp)
+  id("com.google.devtools.ksp")
 }
 
 android {

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
   alias(libs.plugins.android.library)
-  alias(libs.plugins.kotlinAndroid)
   alias(libs.plugins.kotlinCompose)
 }
 

--- a/feature/widgets/build.gradle.kts
+++ b/feature/widgets/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
   alias(libs.plugins.android.library)
-  alias(libs.plugins.kotlinAndroid)
   alias(libs.plugins.kotlinCompose)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,8 @@
 [versions]
 aboutlibraries = "14.2.1"
 androidx-annotation = "1.10.0"
+androidx-benchmark = "1.4.1"
+androidx-profileinstaller = "1.4.1"
 androidx-appcompat = "1.7.1"
 androidx-arch-core-testing = "2.2.0"
 androidx-compose-bom = "2026.06.01"
@@ -34,8 +36,8 @@ coil-compose = "3.5.0"
 desugar = "2.1.5"
 firebaseBom = "34.16.0"
 google-material = "1.14.0"
-gradlePlugin-agp = "8.13.2"
-gradlePlugin-baselineprofile = "1.4.1"
+gradlePlugin-agp = "9.3.1"
+gradlePlugin-baselineprofile = "1.5.0-alpha07"
 gradlePlugin-crashlytics = "3.0.7"
 gradlePlugin-detekt = "1.23.8"
 gradlePlugin-gms = "4.5.0"
@@ -146,8 +148,8 @@ squareup-okio = { module = "com.squareup.okio:okio", version.ref = "squareup-oki
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
-androidx-benchmark-macro-junit4 = { module = "androidx.benchmark:benchmark-macro-junit4", version.ref = "gradlePlugin-baselineprofile" }
-androidx-profileinstaller = { module = "androidx.profileinstaller:profileinstaller", version.ref = "gradlePlugin-baselineprofile" }
+androidx-benchmark-macro-junit4 = { module = "androidx.benchmark:benchmark-macro-junit4", version.ref = "androidx-benchmark" }
+androidx-profileinstaller = { module = "androidx.profileinstaller:profileinstaller", version.ref = "androidx-profileinstaller" }
 screenshot-validation-api = { group = "com.android.tools.screenshot", name = "screenshot-validation-api", version.ref = "gradlePlugin-screenshot" }
 
 [bundles]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Migrates to AGP 9 (built-in Kotlin). Continuation of the #277 dependency sweep, after actions (#336) and the non-breaking group (#337).

## Key decision: Kotlin stays at 2.3.20
AGP 9's built-in Kotlin defaults to KGP **2.2.10** — a downgrade from our 2.3.20. Rather than regress, the root `buildscript` classpath **overrides** built-in Kotlin up to 2.3.20 (KGP + `symbol-processing-gradle-plugin`). KSP is applied versionless in modules since the version now comes from that classpath. This override is very likely the piece a prior attempt missed.

## Changes
- Gradle 8.14.5 → **9.6.1**, AGP 8.13.2 → **9.3.1**
- Removed `org.jetbrains.kotlin.android` from all 16 modules (built-in Kotlin)
- Root buildscript pins KGP + KSP to the catalog Kotlin/KSP versions
- Rewired the kotlinter/kover `subprojects` hook off the Android plugin IDs (old hook keyed on the now-absent `kotlin.android`)
- Dropped the `applicationVariants` APK-rename block — removed API in AGP 9; the release workflow globs `*.apk`, so output naming is unaffected
- Root lint config uses the new `com.android.build.api.dsl.LibraryExtension`
- `baselineprofile` plugin → **1.5.0-alpha07** (only version supporting AGP 9); `profileinstaller` + `benchmark` **libraries** decoupled onto their own stable **1.4.1** refs (nothing alpha ships in the app runtime)

## Verification (local)
- `./gradlew help` ✅
- `staticAnalysisAll test` ✅ (SARIF reports still generate)
- `validateGithubDebugScreenshotTest` ✅ (compose screenshot plugin under AGP 9)
- `:app:assembleGithubRelease` ✅ (R8 minify + proguard)

## Deferred (out of scope)
- `core-ktx 1.19` / `lifecycle 2.11` — require compileSdk 37
- `coroutines 1.11.0` — detekt 1.23.8 type-resolution regression
- Kotlin 2.4.10 — newest KSP is 2.3.10 (unproven pairing)
- aboutlibraries 15